### PR TITLE
Change customer_id to client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Or install it system wide as:
 
 Please read the great documentation at http://plaid.com/docs/ for more information.
 
-Configure the gem with your customer id, secret key, and the environment path you would like to use.
+Configure the gem with your client id, secret key, and the environment path you would like to use.
 
 ```ruby
 Plaid.config do |p|
-    p.customer_id = 'Plaid provided customer ID here'
+    p.client_id = 'Plaid provided client ID here'
     p.secret = 'Plaid provided secret key here'
     p.environment_location = 'URL for the development or production environment'
 end

--- a/lib/plaid/config.rb
+++ b/lib/plaid/config.rb
@@ -1,8 +1,8 @@
 module Plaid
   module Configure
-    attr_writer :customer_id, :secret, :environment_location
+    attr_writer :client_id, :secret, :environment_location
 
-    KEYS = [:customer_id, :secret, :environment_location]
+    KEYS = [:client_id, :secret, :environment_location]
 
     def config
       yield self

--- a/lib/plaid/util.rb
+++ b/lib/plaid/util.rb
@@ -6,7 +6,7 @@ module Plaid
 
     def post(path,options={})
       uri = build_uri(path)
-      options.merge!({client_id: self.instance_variable_get(:'@customer_id') ,secret: self.instance_variable_get(:'@secret')})
+      options.merge!({client_id: self.instance_variable_get(:'@client_id') ,secret: self.instance_variable_get(:'@secret')})
       res = Net::HTTP.post_form(uri,options)
       parse_response(res)
     end
@@ -19,7 +19,7 @@ module Plaid
 
     def patch(path,options={})
       uri = build_uri(path)
-      options.merge!({client_id: self.instance_variable_get(:'@customer_id') ,secret: self.instance_variable_get(:'@secret')})
+      options.merge!({client_id: self.instance_variable_get(:'@client_id') ,secret: self.instance_variable_get(:'@secret')})
       req = Net::HTTP::Patch.new(uri)
       req.body = URI.encode_www_form(options) if options
       req.content_type = 'multipart/form-data'
@@ -29,7 +29,7 @@ module Plaid
 
     def delete(path,options={})
       uri = build_uri(path)
-      options.merge!({client_id: self.instance_variable_get(:'@customer_id') ,secret: self.instance_variable_get(:'@secret')})
+      options.merge!({client_id: self.instance_variable_get(:'@client_id') ,secret: self.instance_variable_get(:'@secret')})
       req = Net::HTTP::Delete.new(uri)
       req.body = URI.encode_www_form(options) if options
       req.content_type = 'multipart/form-data'

--- a/spec/add_user_spec.rb
+++ b/spec/add_user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper.rb'
 describe '.add_user' do
 
   Plaid.config do |p|
-    p.customer_id = 'test_id'
+    p.client_id = 'test_id'
     p.secret = 'test_secret'
     p.environment_location = 'https://tartan.plaid.com/'
   end

--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -4,7 +4,7 @@ describe '#Category' do
 
   before :all do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_secret'
       p.environment_location = 'https://tartan.plaid.com/'
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,7 +2,7 @@
 describe '.config' do
   context 'has valid dev keys' do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_secret'
       p.environment_location = 'https://tartan.plaid.com/'
     end
@@ -12,7 +12,7 @@ describe '.config' do
 
   context 'has valid production keys' do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_secret'
       p.environment_location = 'https://api.plaid.com/'
     end
@@ -22,7 +22,7 @@ describe '.config' do
 
   context 'has invalid dev keys' do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_bad'
       p.environment_location = 'https://tartan.plaid.com/'
     end
@@ -31,7 +31,7 @@ describe '.config' do
 
   context 'has invalid production keys' do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_bad'
       p.environment_location = 'https://api.plaid.com/'
     end

--- a/spec/institution_spec.rb
+++ b/spec/institution_spec.rb
@@ -3,7 +3,7 @@ describe '#Institution' do
 
   before :all do
     Plaid.config do |p|
-      p.customer_id = 'test_id'
+      p.client_id = 'test_id'
       p.secret = 'test_secret'
       p.environment_location = 'https://tartan.plaid.com/'
     end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper.rb'
 describe '#User' do
 
   Plaid.config do |p|
-    p.customer_id = 'test_id'
+    p.client_id = 'test_id'
     p.secret = 'test_secret'
     p.environment_location = 'https://tartan.plaid.com/'
   end


### PR DESCRIPTION
It's called `client_id` in the [actual API call](https://github.com/plaid/plaid-ruby/blob/2ee9df00626e5e9213fcfe34c3161ea5d2e3a013/lib/plaid/util.rb#L9) and in [all the docs](https://plaid.com/docs).

I thought it would be best to keep this consistent in the gem.