### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Plaid.config do |p|
 end
 ```
 
+Example configuration:
+
+```ruby
+Plaid.config do |p|
+    p.customer_id = 'CLIENT_ID_TOKEN'
+    p.secret = 'SECRET_TOKEN'
+    p.environment_location = 'https://tartan.plaid.com/'
+end
+```
+
 Authenticate a user to your desired level of api access (auth / connect).
 
 ```ruby


### PR DESCRIPTION
I was struggling to follow the README, receiving an error: 
```
SocketError: getaddrinfo: nodename nor servname provided, or not known
from /mackerman/.rbenv/versions/2.1.3/lib/ruby/2.1.0/net/http.rb:879:in `initialize'
```

It looks like it was because I wasn't including the trailing slash on the `environment_location` configuration option. 

Probably worth it to fix the README.