### PR TITLE
Plaid.transactions

### DIFF
--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -5,6 +5,8 @@ require 'plaid/models/user'
 require 'plaid/models/institution'
 require 'plaid/models/category'
 
+require 'json'
+
 module Plaid
   autoload :Connection, 'plaid/connection'
 
@@ -35,6 +37,26 @@ module Plaid
       _user.access_token = fully_qualified_token(token, institution_type)
       _user.permissions = api_levels
       api_levels.each { |l| _user.get(l) }
+      return _user
+    end
+
+    # API: public
+    # Given an access code and query options, use this to get a dataset of
+    # transactions and accounts for # a given user. See /connect/get endpoint
+    #
+    # Returns a Plaid::User object with accounts and transactions within
+    # the date range given
+    # Examples:
+    #   Plaid.transactions 'test_wells', account: 'QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK'
+    def transactions(token, options = {})
+      _user = Plaid::User.new
+      _user.access_token = token
+      _user.permit! 'connect'
+
+      # TODO: For 2.0, submit all data as JSON
+      options = JSON.generate(options) if options.kind_of?(Hash)
+
+      _user.get_connect(options: options)
       return _user
     end
 

--- a/lib/plaid/models/transaction.rb
+++ b/lib/plaid/models/transaction.rb
@@ -1,12 +1,13 @@
 module Plaid
   class Transaction
-    attr_accessor :id, :account, :amount, :name, :meta, :location, :pending, :score, :type, :category, :category_id
+    attr_accessor :id, :account, :date, :amount, :name, :meta, :location, :pending, :score, :type, :category, :category_id
 
     # API: semi-private
     # This method updates Plaid::Account with the results returned from the API
     def update(res)
       self.id       = res['_id']
       self.account  = res['_account']
+      self.date     = res['date']
       self.amount   = res['amount']
       self.name     = res['name']
       self.meta     = res['meta']

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper.rb'
 # Authentication flow specs - returns Plaid::User
 RSpec.describe Plaid do
+  let(:api_level) { raise "Define let(:api_level)" }
+  let(:username)  { raise "Define let(:username)" }
+  let(:password)  { raise "Define let(:password)" }
+  let(:type)      { raise "Define let(:type)" }
+  let(:pin)       { nil }
+  let(:options)   { nil }
+
   describe '.add_user' do
     let(:user) { Plaid.add_user api_level, username, password, type, pin, options }
-
-    let(:api_level) { raise "Define let(:api_level)" }
-    let(:username)  { raise "Define let(:username)" }
-    let(:password)  { raise "Define let(:password)" }
-    let(:type)      { raise "Define let(:type)" }
-    let(:pin)       { nil }
-    let(:options)   { nil }
 
     context 'with correct credentials for single user auth' do
       let(:username)  { 'plaid_test' }
@@ -191,6 +191,35 @@ RSpec.describe Plaid do
       context 'gets a fully validated user with all access granted' do
         let(:user) { Plaid.set_user('test_wells',['connect','info','auth']) }
         it { expect(user.transactions).to be_truthy}
+      end
+    end
+  end
+
+  describe '.transactions' do
+    subject { Plaid.transactions(access_token, options) }
+    let(:access_token) { 'test_wells' }
+    let(:options)      { nil }
+
+    context 'without options' do
+      it 'should return all accounts' do
+        expect(subject.accounts).not_to be_empty
+      end
+
+      it 'should return all transactions' do
+        expect(subject.transactions).not_to be_empty
+      end
+    end
+
+    context 'when filering by account' do
+      let(:options) { { account: account } }
+      let(:account) { 'QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK' }
+
+      it 'should return a subset of transactions' do
+        expect(subject.transactions.size).to eql(2)
+      end
+
+      it 'should only return transactions from the requested account' do
+        expect(subject.transactions.map(&:account).uniq).to eql([account])
       end
     end
   end

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -222,5 +222,31 @@ RSpec.describe Plaid do
         expect(subject.transactions.map(&:account).uniq).to eql([account])
       end
     end
+
+    context 'when filtering by date' do
+      let(:options) { { gte: "2014-07-24", lte: "2014-07-25" } }
+
+      it 'should return a subset of transactions' do
+        expect(subject.transactions.size).to eql(1)
+      end
+
+      it 'should only return transactions from the requested date range' do
+        expect(subject.transactions.map(&:date).uniq).to eql(['2014-07-24'])
+      end
+    end
+
+    context 'when filtering by account and date' do
+      let(:options) { { account: account , gte: "2014-07-24", lte: "2014-07-25" } }
+      let(:account) { 'XARE85EJqKsjxLp6XR8ocg8VakrkXpTXmRdOo' }
+
+      it 'should return a subset of transactions' do
+        expect(subject.transactions.size).to eql(1)
+      end
+
+      it 'should only return transactions from the requested account and date range' do
+        expect(subject.transactions.map(&:date).uniq).to eql(['2014-07-24'])
+        expect(subject.transactions.map(&:account).uniq).to eql([account])
+      end
+    end
   end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Plaid::Transaction do
 
     with_results('_id'      =>  'ID')       do it { expect(subject.id).to       eql('ID') }       end
     with_results('_account' =>  'acct')     do it { expect(subject.account).to  eql('acct') }     end
+    with_results('date'     => '00/00/00')  do it { expect(subject.date).to     eql('00/00/00') } end
     with_results('amount'   => 100.00)      do it { expect(subject.amount).to   eql(100.00) }     end
     with_results('name'     =>  'Name')     do it { expect(subject.name).to     eql('Name') }     end
     with_results('meta'     => {} )         do it { expect(subject.meta).to     eql({}) }         end


### PR DESCRIPTION
API: public

`Plaid.transactions` lets you query `/connect/get` with options. Pass it an access-token along with the options. This is intended for use with webhooks, so you can query a subset of transactions when notified by a webhook.

Examples:

```
Plaid.transactions 'test_wells'
Plaid.transactions 'test_wells', account: "XARE85EJqKsjxLp6XR8ocg8VakrkXpTXmRdOo"
Plaid.transactions 'test_wells', pending: true
Plaid.transactions 'test_wells', account: "XARE85EJqKsjxLp6XR8ocg8VakrkXpTXmRdOo", gte: "2014-07-24", lte: "2014-07-25"
```

Additionally: added `date` to `Plaid::Transaction`