### PR TITLE
Added "subtype" for Account

### DIFF
--- a/lib/plaid/models/account.rb
+++ b/lib/plaid/models/account.rb
@@ -1,6 +1,6 @@
 module Plaid
   class Account
-    attr_accessor :available_balance, :current_balance, :institution_type, :meta, :transactions, :numbers, :name, :id, :type
+    attr_accessor :available_balance, :current_balance, :institution_type, :meta, :transactions, :numbers, :name, :id, :type, :subtype
 
     # API: semi-private
     # This method updates Plaid::Account with the results returned from the API
@@ -8,6 +8,10 @@ module Plaid
       self.name = res['name']
       self.id   = res['_id']
       self.type = res['type']
+      # Depository account only, "checkings" or "savings"
+      # Available on live data, but not on the test data
+      self.subtype = res['subtype']
+
       self.meta = res['meta'] if res['meta']
 
       if res['balance']

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Plaid::Account do
     with_results('name' => 'Name') do it { expect(subject.name).to eql('Name') } end
     with_results('_id' =>  'ID')   do it { expect(subject.id).to   eql('ID') }   end
     with_results('type' => 'Type') do it { expect(subject.type).to eql('Type') } end
+    with_results('type' => 'STyp') do it { expect(subject.type).to eql('STyp') } end
     with_results('meta' => nil)    do it { expect(subject.meta).to be_nil }      end
     with_results('meta' => {})     do it { expect(subject.meta).to eql({}) }     end
 


### PR DESCRIPTION
The results returned by Plaid allows you to distinguish between a checkings or a savings account via the `subtype` field. However, this is not available in the test data at the current date. This patch adds code to make `subtype` available to `Plaid::Account` objects.