### PR TITLE
plaid-ruby@1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ruby bindings for the Plaid API
 
 This version is a beta version that contains failing tests for the new 'info' endpoint. While these have been tested individually on real accounts the tests here will fail with the test accounts supplied. These will be updated soon with test credentials.
 
-Latest stable version: **1.5.0**
+Latest stable version: **1.5.1**
 
 This version removes the need to use 'type' in each additional call.
 

--- a/lib/plaid/version.rb
+++ b/lib/plaid/version.rb
@@ -1,3 +1,3 @@
 module Plaid
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
The 1.5.1 release includes https://github.com/plaid/plaid-ruby/pull/59.