### PR TITLE
Clearer Exception Handling for the client user

### DIFF
--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -1,10 +1,12 @@
 require 'plaid/version'
 require 'plaid/config'
+require 'plaid/errors'
 
 require 'plaid/models/user'
 require 'plaid/models/institution'
 require 'plaid/models/category'
 require 'plaid/models/exchange_token_response'
+
 
 require 'json'
 

--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -88,7 +88,7 @@ module Plaid
         when nil
           body
         when 1301, 1401, 1501, 1601
-          raise Plaid::NotFound.new(body['code'], boday['message'], body['resolve'])
+          raise Plaid::NotFound.new(body['code'], body['message'], body['resolve'])
         else
           body
         end

--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -68,15 +68,15 @@ module Plaid
         when 200 then body
         when 201 then { msg: 'Requires further authentication', body: body}
         when 400
-          raise Plaid::BadRequest.new(body['code'], body['resolve'])
+          raise Plaid::BadRequest.new(body['code'], body['message'], body['resolve'])
         when 401
-          raise Plaid::Unauthorized.new(body['code'], body['resolve'])
+          raise Plaid::Unauthorized.new(body['code'], body['message'], body['resolve'])
         when 402
-          raise Plaid::RequestFailed.new(body['code'], body['resolve'])
+          raise Plaid::RequestFailed.new(body['code'], body['message'], body['resolve'])
         when 404
-          raise Plaid::NotFound.new(body['code'], body['resolve'])
+          raise Plaid::NotFound.new(body['code'], body['message'], body['resolve'])
         else
-          raise Plaid::ServerError.new(body['code'], body['resolve'])
+          raise Plaid::ServerError.new(body['code'], body['message'], body['resolve'])
         end
       end
 
@@ -88,7 +88,7 @@ module Plaid
         when nil
           body
         when 1301, 1401, 1501, 1601
-          raise Plaid::NotFound.new(body['code'], body['resolve'])
+          raise Plaid::NotFound.new(body['code'], boday['message'], body['resolve'])
         else
           body
         end

--- a/lib/plaid/errors.rb
+++ b/lib/plaid/errors.rb
@@ -6,6 +6,7 @@ module Plaid
     def initialize(code, message, resolve)
       super(message)
       @code = code
+      @resolve = resolve
     end
   end
 

--- a/lib/plaid/errors.rb
+++ b/lib/plaid/errors.rb
@@ -1,9 +1,10 @@
 module Plaid
   class PlaidError < StandardError
     attr_reader :code
+    attr_reader :resolve
     
-    def initialize(code, msg)
-      super(msg)
+    def initialize(code, message, resolve)
+      super(message)
       @code = code
     end
   end

--- a/lib/plaid/errors.rb
+++ b/lib/plaid/errors.rb
@@ -1,0 +1,25 @@
+module Plaid
+  class PlaidError < StandardError
+    attr_reader :code
+    
+    def initialize(code, msg)
+      super(msg)
+      @code = code
+    end
+  end
+
+  class BadRequest < PlaidError
+  end
+
+  class Unauthorized < PlaidError
+  end
+
+  class RequestFailed < PlaidError
+  end
+
+  class NotFound < PlaidError
+  end
+
+  class ServerError < PlaidError
+  end
+end

--- a/plaid.gemspec
+++ b/plaid.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~>3.1'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-stack_explorer'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,180 @@
+require 'spec_helper'
+
+RSpec.describe Plaid::Connection do
+  
+  let(:stub_url) { "https://tartan.plaid.com/testing" }
+  let(:bad_req_response) {  {"code": 1005, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
+  let(:unauth_response) { {"code": 1105, "message" => "bad access_token", "resolve" => "This access_token appears to be corrupted."}.to_json }
+  let(:req_fail_response) {  {"code": 1200, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
+  let(:req_not_found) {  {"code": 1600, "message" => "product not found", "resolve" => "This product doesn't exist yet, we're actually not sure how you reached this error..."}.to_json }
+
+  describe "#post" do
+    it "should send a post request" do
+      stub = stub_request(:post, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      Plaid::Connection.post("testing")
+      expect(stub).to have_requested(:post, stub_url)
+    end
+
+    it "should return response on 200 response" do
+      stub = stub_request(:post, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      response = Plaid::Connection.post("testing")
+      expect(response).to eq({"response" => "OK"})
+    end
+
+    it "should return message on 201 response" do
+      stub = stub_request(:post, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
+      response = Plaid::Connection.post("testing")
+      expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
+    end
+
+    it "should throw Plaid::BadRequest on 400 response" do
+      stub = stub_request(:post, stub_url).to_return(status: 400, body: bad_req_response)
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+    end
+
+    it "should throw Plaid::Unauthorized on 401 response" do 
+      stub = stub_request(:post, stub_url).to_return(status: 401, body: unauth_response)
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+    end
+
+    it "should throw Plaid::RequestFailed on 402 response" do
+      stub = stub_request(:post, stub_url).to_return(status: 402, body: req_fail_response)
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+    end
+
+    it "should throw a Plaid::NotFound on 404 response" do 
+      stub = stub_request(:post, stub_url).to_return(status: 404, body: req_not_found)
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::NotFound, "product not found")
+    end
+  end
+
+  describe "#get" do
+    it "should send a get request" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      Plaid::Connection.get("testing")
+      expect(stub).to have_requested(:get, stub_url)
+    end
+    
+    it "should return response when no code available" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      response = Plaid::Connection.get("testing")
+      expect(response).to eq({"response" => "OK"})
+    end
+    
+    it "should return response when code not [1301, 1401, 1501, 1601]" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1502, "response" => "OK"}.to_json})
+      response = Plaid::Connection.get("testing")
+      expect(response).to eq({"code" => 1502, "response" => "OK"})
+    end
+
+    it "should throw 404 for 1301 code" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1301, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+    end
+    
+    it "should throw 404 for 1401 code" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1401, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+    end
+    
+    it "should throw 404 for 1501 code" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1501, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+    end
+    
+    it "should throw 404 for 1601 code" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1601, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+    end
+
+  end
+
+  describe "#secure_get" do
+    it "should send a secure get request" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      Plaid::Connection.secure_get("testing", "test_wells")
+      expect(stub).to have_requested(:get, stub_url).with(:body => {:access_token => "test_wells"}) 
+    end
+
+    it "should return response on 200 response" do
+      stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      response = Plaid::Connection.secure_get("testing", "test_wells")
+      expect(response).to eq({"response" => "OK"})
+    end
+
+    it "should return message on 201 response" do
+      stub = stub_request(:get, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
+      response = Plaid::Connection.secure_get("testing", "test_wells")
+      expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
+    end
+
+    it "should throw Plaid::BadRequest on 400 response" do
+      stub = stub_request(:get, stub_url).to_return(status: 400, body: bad_req_response)
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+    end
+
+    it "should throw Plaid::Unauthorized on 401 response" do 
+      stub = stub_request(:get, stub_url).to_return(status: 401, body: unauth_response)
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+    end
+
+    it "should throw Plaid::RequestFailed on 402 response" do
+      stub = stub_request(:get, stub_url).to_return(status: 402, body: req_fail_response)
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+    end
+
+    it "should throw a Plaid::NotFound on 404 response" do 
+      stub = stub_request(:get, stub_url).to_return(status: 404, body: req_not_found)
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::NotFound, "product not found")
+    end
+  end
+
+  describe "#patch" do
+    it "should send a patch request" do
+      stub = stub_request(:patch, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      Plaid::Connection.patch("testing")
+      expect(stub).to have_requested(:patch, stub_url)
+    end
+    
+    it "should return response on 200 response" do
+      stub = stub_request(:patch, stub_url).to_return({:body => {"response" => "OK"}.to_json})
+      response = Plaid::Connection.patch("testing")
+      expect(response).to eq({"response" => "OK"})
+    end
+
+    it "should return message on 201 response" do
+      stub = stub_request(:patch, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
+      response = Plaid::Connection.patch("testing")
+      expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
+    end
+
+    it "should throw Plaid::BadRequest on 400 response" do
+      stub = stub_request(:patch, stub_url).to_return(status: 400, body: bad_req_response)
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+    end
+
+    it "should throw Plaid::Unauthorized on 401 response" do 
+      stub = stub_request(:patch, stub_url).to_return(status: 401, body: unauth_response)
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+    end
+
+    it "should throw Plaid::RequestFailed on 402 response" do
+      stub = stub_request(:patch, stub_url).to_return(status: 402, body: req_fail_response)
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+    end
+
+    it "should throw a Plaid::NotFound on 404 response" do 
+      stub = stub_request(:patch, stub_url).to_return(status: 404, body: req_not_found)
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::NotFound, "product not found")
+    end
+  end
+
+  describe "#delete" do
+    it "should send a delete request" do
+      stub = stub_request(:delete, stub_url)
+      Plaid::Connection.delete("testing")
+      expect(stub).to have_requested(:delete, stub_url)
+    end
+  end
+
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 RSpec.describe Plaid::Connection do
   
   let(:stub_url) { "https://tartan.plaid.com/testing" }
-  let(:bad_req_response) {  {"code": 1005, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
-  let(:unauth_response) { {"code": 1105, "message" => "bad access_token", "resolve" => "This access_token appears to be corrupted."}.to_json }
-  let(:req_fail_response) {  {"code": 1200, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
-  let(:req_not_found) {  {"code": 1600, "message" => "product not found", "resolve" => "This product doesn't exist yet, we're actually not sure how you reached this error..."}.to_json }
+  let(:bad_req_response) {  {"code" => 1005, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
+  let(:unauth_response) { {"code" => 1105, "message" => "bad access_token", "resolve" => "This access_token appears to be corrupted."}.to_json }
+  let(:req_fail_response) {  {"code" => 1200, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
+  let(:req_not_found) {  {"code" =>  1600, "message" => "product not found", "resolve" => "This product doesn't exist yet, we're actually not sure how you reached this error..."}.to_json }
 
   describe "#post" do
     it "should send a post request" do

--- a/spec/plaid_error_spec.rb
+++ b/spec/plaid_error_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe Plaid::PlaidError do
+  describe "#new" do
+    it "should allow code, message and resolution" do
+      error = Plaid::PlaidError.new 1, "testing", "fix it"
+      expect(error.code).to eq(1)
+      expect(error.message).to eq("testing")
+      expect(error.resolve).to eq("fix it")
+    end
+  end
+end

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -28,7 +28,13 @@ RSpec.describe Plaid do
 
         context 'when account is locked' do
           let(:password) { 'plaid_locked' }
-          it { expect { user }.to raise_error }
+          it "raises a locked error" do
+            expect { user }.to raise_error { |error|
+              expect(error).to be_a(Plaid::RequestFailed)
+              expect(error.code).to eq(1205)
+            }
+          end
+          
         end
 
         context 'with connection options' do

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Plaid do
 
         context 'when account is locked' do
           let(:password) { 'plaid_locked' }
-          it { expect(user.api_res).to eq 'User account is locked' }
+          it { expect { user }.to raise_error }
         end
 
         context 'with connection options' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ Bundler.setup
 require 'plaid'
 require 'pry' if ENV['DEBUG']
 
+require 'webmock/rspec'
+WebMock.allow_net_connect!
+
 Plaid.config do |p|
   p.customer_id = 'test_id'
   p.secret = 'test_secret'


### PR DESCRIPTION
I wanted clearer exceptions and access to the code/message that the API was handing back to me, and unfortunately, api_res didn't seem to cover all the use cases.  I created a PlaidError which encapsulated the data I wanted from the request. Another thing I could do, is actually just jam the json object in there and let anyone access the full response from the api on error (sometimes very useful). This also helps refactor out the "error_handler" function, which seemed like a good benefit. 

This gives me the freedom to catch a particular exception, and cleanup according to the api response code that you guys use. Since your api is pretty sweet and has so many various states that an account can be in, this is essential for someone like me to create a robust ruby app with. I've updated the spec file for catching the account locked error, but I'm happy to update it to include various other exceptions as well. 

This seems like a good first step, but most likely in another pull request, I probably will add a list of all error codes onto the Plaid module so that end-users like myself can do easy comparisons without having to maintain our own list of codes. 
eg:

```ruby
  begin
     user.add_user('connect', 'username', 'password', 'superbank')
  rescue Plaid::RequestFailed => e
      if e.code == Plaid::ACCOUNT_LOCKED
         # Do the special locked code path you got going on
     end
  end
```

Let me know if there are any issues with the PR or if I can help in anyway. Thanks