### PR TITLE
Reducing required Ruby version

### DIFF
--- a/plaid.gemspec
+++ b/plaid.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby gem wrapper for the Plaid API. Read more at the homepage, the wiki, or the plaid documentation.'
   spec.homepage      = 'https://github.com/plaid/plaid-ruby'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.1.3'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -24,3 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-stack_explorer'
 end
+


### PR DESCRIPTION
No sense locking people to 2.1.3+ if it's not needed.

(FWIW, I tried dropping it down to 1.9, but the specs failed.)