### PR TITLE
Fixed invalid code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ user = Plaid.set_user('access_token')
 ```
 
 ```ruby
-user = Plaid.set_user('access_token', 'wells')
+user = Plaid.set_user('access_token', ['connect'])
 ```
 
 ### Exchanging a Link public_token for a Plaid access_token


### PR DESCRIPTION
Example Plaid.set_user('access_token', 'wells') is incorrect. Array with auth levels should be passed instead.