### PR TITLE
Support added for ruby 1.9.3

### DIFF
--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -9,7 +9,11 @@ module Plaid
       def post(path, options = {})
         uri = build_uri(path)
         options.merge!(client_id: Plaid.customer_id, secret: Plaid.secret)
-        res = Net::HTTP.post_form(uri,options)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == 'https')
+        request = Net::HTTP::Post.new(uri.path)
+        request.set_form_data(options)
+        res = http.request(request)
         parse_response(res)
       end
 

--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -20,15 +20,18 @@ module Plaid
       # API: semi-private
       def get(path, id = nil)
         uri = build_uri(path,id)
-        res = Net::HTTP.get(uri)
-        parse_get_response(res)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == 'https')
+        request = Net::HTTP::Get.new(uri.path)
+        res = http.request(request)
+        parse_get_response(res.body)
       end
 
       # API: semi-private
       def secure_get(path, access_token, options = {})
         uri = build_uri(path)
         options.merge!({access_token:access_token})
-        req = Net::HTTP::Get.new(uri)
+        req = Net::HTTP::Get.new(uri.path)
         req.body = URI.encode_www_form(options) if options
         req.content_type = 'application/x-www-form-urlencoded'
         res = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') { |http| http.request(req) }
@@ -39,7 +42,7 @@ module Plaid
       def patch(path, options = {})
         uri = build_uri(path)
         options.merge!(client_id: Plaid.customer_id, secret: Plaid.secret)
-        req = Net::HTTP::Patch.new(uri)
+        req = Net::HTTP::Patch.new(uri.path)
         req.body = URI.encode_www_form(options) if options
         req.content_type = 'application/x-www-form-urlencoded'
         res = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') { |http| http.request(req) }
@@ -50,7 +53,7 @@ module Plaid
       def delete(path, options = {})
         uri = build_uri(path)
         options.merge!(client_id: Plaid.customer_id, secret: Plaid.secret)
-        req = Net::HTTP::Delete.new(uri)
+        req = Net::HTTP::Delete.new(uri.path)
         req.body = URI.encode_www_form(options) if options
         req.content_type = 'application/x-www-form-urlencoded'
         Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') { |http| http.request(req) }

--- a/plaid.gemspec
+++ b/plaid.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby gem wrapper for the Plaid API. Read more at the homepage, the wiki, or the plaid documentation.'
   spec.homepage      = 'https://github.com/plaid/plaid-ruby'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Support added for ruby 1.9.3
Successfully executed specs both in 1.9.3 & 2.2.0

=> ruby-2.2.0 [ i686 ]
Finished in 1 minute 54.09 seconds (files took 0.31953 seconds to load)
122 examples, 0 failures, 4 pending

=* ruby-1.9.3-p551 [ i686 ]
Finished in 2 minutes 23.5 seconds (files took 0.37978 seconds to load)
122 examples, 0 failures, 4 pending
