### PR TITLE
wording improvements and some ruby fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 Authenticate a user to your desired level of api access (auth / connect).
 
 ```ruby
-user = Plaid.add_user('auth','plaid_test','plaid_good','wells')
+user = Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'wells')
 ```
 
 If the authentication requires a pin, you can pass it in as the fifth argument:
@@ -61,7 +61,7 @@ user = Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'usaa', '1234')
 To add options such as `login_only` or `webhooks`, use the sixth argument:
 
 ```ruby
-user = Plaid.add_user('auth','plaid_test','plaid_good','wells', nil, { login_only: true, webhooks: 'https://example.org/callbacks/plaid')
+user = Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'wells', nil, { login_only: true, webhooks: 'https://example.org/callbacks/plaid')
 ```
 
 ### Restoring a Plaid User using an access token
@@ -101,7 +101,7 @@ user.accounts.each { |account| print account.meta['name'] + "\n"}
 
 Methods marked with `API: public` are officially supported by the gem maintainers. Since
 we are using semantic versioning (http://semver.org/spec/v2.0.0.html), the maintainers are
-commited to backwards-compatibility support for these API calls when we update the Minor
+committed to backwards-compatibility support for these API calls when we update the Minor
 version. So for example, going from version 1.4.x to 1.5.x will not change these public
 API calls.
 
@@ -109,7 +109,7 @@ However, we may change these method signatures or even the gem architecture when
 the Major number. For example, we have some breaking changes in mind with version 2.0
 
 Methods marked with `API: semi-private` are used internally for consistency. While it is
-possible to monkey-patch against them for your own use, the maintainers make no gaurantees
+possible to monkey-patch against them for your own use, the maintainers make no guarantees
 on backwards compatibility.
 
 ## Learn More

--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -7,7 +7,6 @@ require 'plaid/models/institution'
 require 'plaid/models/category'
 require 'plaid/models/exchange_token_response'
 
-
 require 'json'
 
 module Plaid
@@ -51,7 +50,7 @@ module Plaid
       _user.access_token = fully_qualified_token(token, institution_type)
       _user.permissions = api_levels
       api_levels.each { |l| _user.get(l) }
-      return _user
+      _user
     end
 
     # API: public
@@ -71,7 +70,7 @@ module Plaid
       options = JSON.generate(options) if options.kind_of?(Hash)
 
       _user.get_connect(options: options)
-      return _user
+      _user
     end
 
     # API: public

--- a/lib/plaid/models/transaction.rb
+++ b/lib/plaid/models/transaction.rb
@@ -10,7 +10,7 @@ module Plaid
       @name = fields['name']
       @location = fields['meta'].nil? ? {} : fields['meta']['location']
       @pending = fields['pending']
-      @pendingTransaction = fields['_pendingTransaction']
+      @pending_transaction = fields['_pendingTransaction']
       @score = fields['score']
       @cat = Category.new({ 'id' => fields['category_id'], 'hierarchy' => fields['category'], 'type' => fields['type'] })
 

--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -83,7 +83,7 @@ module Plaid
         set_mfa_request!(res)
       end
 
-      return self
+      self
     end
 
     # Internal helper methods

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper.rb'
-
-RSpec.describe Plaid::Account do
+describe Plaid::Account do
   # API: semi-private
   describe '.new' do
     subject { Plaid::Account.new(results) }

--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper.rb'
-
-RSpec.describe Plaid::Category do
+describe Plaid::Category do
   context 'when a single category is found' do
     let(:category) { Plaid.category('17001013') }
     it { expect(category).to be_kind_of(Plaid::Category) }

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper.rb'
-
-RSpec.describe 'Plaid.config' do
+describe 'Plaid.config' do
   around(:each) do |example|
     old_customer_id          = Plaid.customer_id
     old_secret               = Plaid.secret
@@ -27,19 +25,19 @@ RSpec.describe 'Plaid.config' do
   let(:prod_url) { 'https://api.plaid.com/' }
 
 
-  let(:user) { Plaid.add_user('connect','plaid_test','plaid_good','wells') }
+  let(:user) { Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'wells') }
 
   context ':environment_location' do
     context 'with trailing slash' do
       let(:environment_location) { 'http://example.org/' }
-      it 'should leave it as-is' do
+      it 'leaves it as-is' do
         expect(Plaid.environment_location).to eql(environment_location)
       end
     end
 
     context 'without trailing slash' do
       let(:environment_location) { 'http://example.org' }
-      it 'should add a trailing slash' do
+      it 'adds a trailing slash' do
         expect(Plaid.environment_location).to eql(environment_location + '/')
       end
     end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,7 +1,4 @@
-require 'spec_helper'
-
-RSpec.describe Plaid::Connection do
-  
+describe Plaid::Connection do
   let(:stub_url) { "https://tartan.plaid.com/testing" }
   let(:bad_req_response) {  {"code" => 1005, "message" => "invalid credentials", "resolve" => "The username or password provided is not correct."}.to_json }
   let(:unauth_response) { {"code" => 1105, "message" => "bad access_token", "resolve" => "This access_token appears to be corrupted."}.to_json }
@@ -9,80 +6,80 @@ RSpec.describe Plaid::Connection do
   let(:req_not_found) {  {"code" =>  1600, "message" => "product not found", "resolve" => "This product doesn't exist yet, we're actually not sure how you reached this error..."}.to_json }
 
   describe "#post" do
-    it "should send a post request" do
+    it "sends a post request" do
       stub = stub_request(:post, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       Plaid::Connection.post("testing")
       expect(stub).to have_requested(:post, stub_url)
     end
 
-    it "should return response on 200 response" do
+    it "returns response on 200 response" do
       stub = stub_request(:post, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       response = Plaid::Connection.post("testing")
       expect(response).to eq({"response" => "OK"})
     end
 
-    it "should return message on 201 response" do
+    it "returns message on 201 response" do
       stub = stub_request(:post, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
       response = Plaid::Connection.post("testing")
       expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
     end
 
-    it "should throw Plaid::BadRequest on 400 response" do
+    it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:post, stub_url).to_return(status: 400, body: bad_req_response)
       expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
     end
 
-    it "should throw Plaid::Unauthorized on 401 response" do 
+    it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:post, stub_url).to_return(status: 401, body: unauth_response)
       expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
     end
 
-    it "should throw Plaid::RequestFailed on 402 response" do
+    it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:post, stub_url).to_return(status: 402, body: req_fail_response)
       expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
     end
 
-    it "should throw a Plaid::NotFound on 404 response" do 
+    it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:post, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::NotFound, "product not found")
     end
   end
 
   describe "#get" do
-    it "should send a get request" do
+    it "sends a get request" do
       stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       Plaid::Connection.get("testing")
       expect(stub).to have_requested(:get, stub_url)
     end
-    
-    it "should return response when no code available" do
+
+    it "returns response when no code available" do
       stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       response = Plaid::Connection.get("testing")
       expect(response).to eq({"response" => "OK"})
     end
-    
-    it "should return response when code not [1301, 1401, 1501, 1601]" do
+
+    it "returns response when code not [1301, 1401, 1501, 1601]" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1502, "response" => "OK"}.to_json})
       response = Plaid::Connection.get("testing")
       expect(response).to eq({"code" => 1502, "response" => "OK"})
     end
 
-    it "should throw 404 for 1301 code" do
+    it "throws 404 for 1301 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1301, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
       expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
     end
-    
-    it "should throw 404 for 1401 code" do
+
+    it "throws 404 for 1401 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1401, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
       expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
     end
-    
-    it "should throw 404 for 1501 code" do
+
+    it "throws 404 for 1501 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1501, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
       expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
     end
-    
-    it "should throw 404 for 1601 code" do
+
+    it "throws 404 for 1601 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1601, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
       expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
     end
@@ -90,91 +87,90 @@ RSpec.describe Plaid::Connection do
   end
 
   describe "#secure_get" do
-    it "should send a secure get request" do
+    it "sends a secure get request" do
       stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       Plaid::Connection.secure_get("testing", "test_wells")
-      expect(stub).to have_requested(:get, stub_url).with(:body => {:access_token => "test_wells"}) 
+      expect(stub).to have_requested(:get, stub_url).with(:body => {:access_token => "test_wells"})
     end
 
-    it "should return response on 200 response" do
+    it "returns response on 200 response" do
       stub = stub_request(:get, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       response = Plaid::Connection.secure_get("testing", "test_wells")
       expect(response).to eq({"response" => "OK"})
     end
 
-    it "should return message on 201 response" do
+    it "returns message on 201 response" do
       stub = stub_request(:get, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
       response = Plaid::Connection.secure_get("testing", "test_wells")
       expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
     end
 
-    it "should throw Plaid::BadRequest on 400 response" do
+    it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:get, stub_url).to_return(status: 400, body: bad_req_response)
       expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::BadRequest, "invalid credentials")
     end
 
-    it "should throw Plaid::Unauthorized on 401 response" do 
+    it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:get, stub_url).to_return(status: 401, body: unauth_response)
       expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::Unauthorized, "bad access_token")
     end
 
-    it "should throw Plaid::RequestFailed on 402 response" do
+    it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:get, stub_url).to_return(status: 402, body: req_fail_response)
       expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
     end
 
-    it "should throw a Plaid::NotFound on 404 response" do 
+    it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:get, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::NotFound, "product not found")
     end
   end
 
   describe "#patch" do
-    it "should send a patch request" do
+    it "sends a patch request" do
       stub = stub_request(:patch, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       Plaid::Connection.patch("testing")
       expect(stub).to have_requested(:patch, stub_url)
     end
-    
-    it "should return response on 200 response" do
+
+    it "returns response on 200 response" do
       stub = stub_request(:patch, stub_url).to_return({:body => {"response" => "OK"}.to_json})
       response = Plaid::Connection.patch("testing")
       expect(response).to eq({"response" => "OK"})
     end
 
-    it "should return message on 201 response" do
+    it "returns message on 201 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 201, body: {"response" => "OK"}.to_json)
       response = Plaid::Connection.patch("testing")
       expect(response).to eq({:msg => "Requires further authentication", :body => {"response" => "OK"}})
     end
 
-    it "should throw Plaid::BadRequest on 400 response" do
+    it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 400, body: bad_req_response)
       expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
     end
 
-    it "should throw Plaid::Unauthorized on 401 response" do 
+    it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 401, body: unauth_response)
       expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
     end
 
-    it "should throw Plaid::RequestFailed on 402 response" do
+    it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 402, body: req_fail_response)
       expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
     end
 
-    it "should throw a Plaid::NotFound on 404 response" do 
+    it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::NotFound, "product not found")
     end
   end
 
   describe "#delete" do
-    it "should send a delete request" do
+    it "sends a delete request" do
       stub = stub_request(:delete, stub_url)
       Plaid::Connection.delete("testing")
       expect(stub).to have_requested(:delete, stub_url)
     end
   end
-
 end

--- a/spec/institution_spec.rb
+++ b/spec/institution_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper.rb'
-
-RSpec.describe Plaid::Institution do
+describe Plaid::Institution do
   context 'when a single institution is found' do
     let(:institution) { Plaid.institution('5301a93ac140de84910000e0') }
     it { expect(institution).to be_kind_of(Plaid::Institution) }

--- a/spec/plaid_error_spec.rb
+++ b/spec/plaid_error_spec.rb
@@ -1,8 +1,6 @@
-require 'spec_helper'
-
-RSpec.describe Plaid::PlaidError do
+describe Plaid::PlaidError do
   describe "#new" do
-    it "should allow code, message and resolution" do
+    it "allows code, message and resolution" do
       error = Plaid::PlaidError.new 1, "testing", "fix it"
       expect(error.code).to eq(1)
       expect(error.message).to eq("testing")

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper.rb'
 # Authentication flow specs - returns Plaid::User
-RSpec.describe Plaid do
+
+describe Plaid do
   let(:api_level) { raise "Define let(:api_level)" }
   let(:username)  { raise "Define let(:username)" }
   let(:password)  { raise "Define let(:password)" }
@@ -34,7 +34,7 @@ RSpec.describe Plaid do
               expect(error.code).to eq(1205)
             }
           end
-          
+
         end
 
         context 'with connection options' do
@@ -195,7 +195,7 @@ RSpec.describe Plaid do
       end
 
       context 'gets a fully validated user with all access granted' do
-        let(:user) { Plaid.set_user('test_wells',['connect','info','auth']) }
+        let(:user) { Plaid.set_user('test_wells', ['connect', 'info', 'auth']) }
         it { expect(user.transactions).to be_truthy}
       end
     end
@@ -213,24 +213,24 @@ RSpec.describe Plaid do
     let(:options)      { nil }
 
     context 'without options' do
-      it 'should return all accounts' do
+      it 'returns all accounts' do
         expect(subject.accounts).not_to be_empty
       end
 
-      it 'should return all transactions' do
+      it 'returns all transactions' do
         expect(subject.transactions).not_to be_empty
       end
     end
 
-    context 'when filering by account' do
+    context 'when filtering by account' do
       let(:options) { { account: account } }
       let(:account) { 'QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK' }
 
-      it 'should return a subset of transactions' do
+      it 'returns a subset of transactions' do
         expect(subject.transactions.size).to eql(2)
       end
 
-      it 'should only return transactions from the requested account' do
+      it 'return only transactions from the requested account' do
         expect(subject.transactions.map(&:account).uniq).to eql([account])
       end
     end
@@ -238,11 +238,11 @@ RSpec.describe Plaid do
     context 'when filtering by date' do
       let(:options) { { gte: "2014-07-24", lte: "2014-07-25" } }
 
-      it 'should return a subset of transactions' do
+      it 'returns a subset of transactions' do
         expect(subject.transactions.size).to eql(1)
       end
 
-      it 'should only return transactions from the requested date range' do
+      it 'return only transactions from the requested date range' do
         expect(subject.transactions.map(&:date).uniq).to eql(['2014-07-24'])
       end
     end
@@ -251,11 +251,11 @@ RSpec.describe Plaid do
       let(:options) { { account: account , gte: "2014-07-24", lte: "2014-07-25" } }
       let(:account) { 'XARE85EJqKsjxLp6XR8ocg8VakrkXpTXmRdOo' }
 
-      it 'should return a subset of transactions' do
+      it 'returns a subset of transactions' do
         expect(subject.transactions.size).to eql(1)
       end
 
-      it 'should only return transactions from the requested account and date range' do
+      it 'returns only transactions from the requested account and date range' do
         expect(subject.transactions.map(&:date).uniq).to eql(['2014-07-24'])
         expect(subject.transactions.map(&:account).uniq).to eql([account])
       end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper.rb'
-
-RSpec.describe Plaid::Transaction do
+describe Plaid::Transaction do
   # API: semi-private
   describe '.new' do
     # The reason this looks weird is because it is. This will be refactored for 2.0

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,26 +1,23 @@
-require 'spec_helper.rb'
-
-RSpec.describe Plaid::User do
-  let(:auth_user)    { Plaid.add_user('auth',   'plaid_test', 'plaid_good', 'wells') }
-  let(:connect_user) { Plaid.add_user('connect','plaid_test', 'plaid_good', 'wells') }
-  let(:info_user)    { Plaid.add_user('info',   'plaid_test', 'plaid_good', 'wells') }
+describe Plaid::User do
+  let(:auth_user)    { Plaid.add_user('auth',    'plaid_test', 'plaid_good', 'wells') }
+  let(:connect_user) { Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'wells') }
+  let(:info_user)    { Plaid.add_user('info',    'plaid_test', 'plaid_good', 'wells') }
 
   context 'user vars' do
-
     context 'valid user has accounts and accounts contain id attribute' do
-      let(:user) { Plaid.add_user('connect','plaid_test','plaid_good','wells') }
+      let(:user) { Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'wells') }
       it { expect(user.accounts.first.id).not_to be_nil }
     end
 
     context 'valid user has accounts and accounts contain type attribute' do
-      let(:user) { Plaid.add_user('connect','plaid_test','plaid_good','wells') }
+      let(:user) { Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'wells') }
       it { expect(user.accounts.first.type).to eq('depository') }
     end
   end
 
   # MFA specs - after user is instantiated,
   describe '#mfa_authentication' do
-    let(:user) { Plaid.add_user('connect','plaid_test', 'plaid_good','bofa') }
+    let(:user) { Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'bofa') }
     let(:new_mfa_user) { user.mfa_authentication('tomato') }
 
     context 'enters correct credentials for MFA auth and authenticates' do
@@ -39,7 +36,7 @@ RSpec.describe Plaid::User do
 
     context 'enters incorrect credentials for MFA auth' do
       let(:mfa_user) { user.mfa_authentication('tomato') }
-      let(:mfa_bad)  { mfa_user; Plaid.add_user('connect','plaid_test', 'plaid_good','bofa') }
+      let(:mfa_bad)  { mfa_user; Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'bofa') }
       it { expect { mfa_bad.mfa_authentication('bad') }.to raise_error }
     end
 
@@ -59,7 +56,7 @@ RSpec.describe Plaid::User do
     end
 
     context 'selects MFA method and returns successful response' do
-      let(:user) { Plaid.add_user('auth','plaid_test','plaid_good','chase',nil,'{"list":true}') }
+      let(:user) { Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'chase', nil, '{"list":true}') }
       let(:new_mfa_user) { user.select_mfa_method({mask: 'xxx-xxx-5309' }, 'chase') }
       let(:expected_pending_questions) do
         {
@@ -72,7 +69,7 @@ RSpec.describe Plaid::User do
     end
 
     context 'selects MFA method, and delivers correct payload to authenticate user' do
-      let(:user) { Plaid.add_user('auth','plaid_test','plaid_good','chase',nil,'{"list":true}') }
+      let(:user) { Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'chase', nil, '{"list":true}') }
       let(:user_select_method) { user.select_mfa_method({mask:'xxx-xxx-5309'}) }
       let(:new_mfa_user) { user_select_method.mfa_authentication(1234) }
 
@@ -118,14 +115,14 @@ RSpec.describe Plaid::User do
 
   describe '#get_balance' do
     subject { user.tap(&:update_balance) }
-    let(:user) { Plaid.add_user('info','plaid_test','plaid_good','wells') }
+    let(:user) { Plaid.add_user('info', 'plaid_test', 'plaid_good', 'wells') }
 
     context 'updates user accounts' do
       it { expect(subject.accounts).not_to be_empty }
     end
 
     # TODO: This test needs to be rewritten better, such as using #uniq instead of this
-    context 'should not double up accounts or transactions' do
+    context 'does not double up accounts or transactions' do
       let(:total_duplicates) { duplicate_accounts.length + duplicate_transactions.length }
       let(:duplicate_accounts)     { subject.accounts.select {|element| user.accounts.count(element) > 1} }
       let(:duplicate_transactions) { subject.transactions.select {|element| user.transactions.count(element) > 1} }
@@ -137,7 +134,7 @@ RSpec.describe Plaid::User do
     let(:info_user) { Plaid.add_user('info', 'plaid_test', 'plaid_good', 'wells') }
     context 'updates information correctly' do
       # TODO: This test needs to pass, currently test credentials are failing
-      pending { expect { info_user.update_info('plaid_test','plaid_good') }.to_not raise_error  }
+      pending { expect { info_user.update_info('plaid_test', 'plaid_good') }.to_not raise_error  }
     end
   end
 
@@ -168,7 +165,7 @@ RSpec.describe Plaid::User do
     end
   end
 
-  # This stuff needs to be tested and rewritten. Have alredy
+  # This stuff needs to be tested and rewritten. Have already
   # surfaced up a bug in it
   pending "#populate_user"
 


### PR DESCRIPTION
1) readme wording improvements
2) rspec imports simplified by using `.rspec`. bonus: now it has colors
3) remove unnecessary `return` operators
4) fix attr_accessor assignment in `Transaction` class
5) few spec example description improvements according to http://betterspecs.org/ suggestions