### PR TITLE
Handling an empty response from the server.

### DIFF
--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -70,9 +70,10 @@ module Plaid
       private
 
       def parse_response(res)
-        json = res.body
         # unfortunately, the JSON gem will raise an exception if the response is empty
-        body = json.length >= 2 ? JSON.parse(json) : nil
+        raise Plaid::ServerError.new(res.code, res.msg, '') if res.body.length < 2
+        # we got a response from the server, so parse it
+        body = JSON.parse(res.body)
         case res.code.delete('.').to_i
         when 200 then body
         when 201 then { msg: 'Requires further authentication', body: body}

--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -71,7 +71,7 @@ module Plaid
 
       def parse_response(res)
         # unfortunately, the JSON gem will raise an exception if the response is empty
-        raise Plaid::ServerError.new(res.code, res.msg, '') if res.body.length < 2
+        raise Plaid::ServerError.new(res.code, res.msg, '') if res.body.to_s.length < 2
         # we got a response from the server, so parse it
         body = JSON.parse(res.body)
         case res.code.delete('.').to_i

--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -70,7 +70,9 @@ module Plaid
       private
 
       def parse_response(res)
-        body = JSON.parse(res.body)
+        json = res.body
+        # unfortunately, the JSON gem will raise an exception if the response is empty
+        body = json.length >= 2 ? JSON.parse(json) : nil
         case res.code.delete('.').to_i
         when 200 then body
         when 201 then { msg: 'Requires further authentication', body: body}

--- a/lib/plaid/version.rb
+++ b/lib/plaid/version.rb
@@ -1,3 +1,3 @@
 module Plaid
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -43,6 +43,11 @@ describe Plaid::Connection do
       stub = stub_request(:post, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::NotFound, "product not found")
     end
+
+    it "throws a Plaid::ServerError on empty response" do
+      stub = stub_request(:post, stub_url).to_return(status: 504, body: '')
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::ServerError, '')
+    end
   end
 
   describe "#get" do
@@ -124,6 +129,11 @@ describe Plaid::Connection do
       stub = stub_request(:get, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::NotFound, "product not found")
     end
+
+    it "throws a Plaid::ServerError on empty response" do
+      stub = stub_request(:get, stub_url).to_return(status: 504, body: '')
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::ServerError, '')
+    end
   end
 
   describe "#patch" do
@@ -163,6 +173,11 @@ describe Plaid::Connection do
     it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 404, body: req_not_found)
       expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::NotFound, "product not found")
+    end
+
+    it "throws a Plaid::ServerError on empty response" do
+      stub = stub_request(:patch, stub_url).to_return(status: 504, body: '')
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::ServerError, '')
     end
   end
 


### PR DESCRIPTION
This is very unlikely when using tartan or production, but when using Plaid's internal development/testing environments this happens occasionally.

This is an attempt to handle this case gracefully, instead of raising a `JSON::ParserError` exception.

c.p. https://stackoverflow.com/questions/8390256/a-json-text-must-at-least-contain-two-octets