### PR TITLE
Fix Account#name to use the right hash key

### DIFF
--- a/lib/plaid/models/account.rb
+++ b/lib/plaid/models/account.rb
@@ -4,7 +4,7 @@ module Plaid
 
     def initialize(hash)
       @id   = hash['_id']
-      @name = hash['name']
+      @name = hash['meta']['name'] if hash['meta']
       @type = hash['type']
       @meta = hash['meta']
       @institution_type  = hash['institution_type']

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -10,7 +10,7 @@ describe Plaid::Account do
       end
     end
 
-    with_results('name' => 'Name') do it { expect(subject.name).to eql('Name') } end
+    with_results('meta' => {'name' => 'Name'}) do it { expect(subject.name).to eql('Name') } end
     with_results('_id' =>  'ID')   do it { expect(subject.id).to   eql('ID') }   end
     with_results('type' => 'Type') do it { expect(subject.type).to eql('Type') } end
     with_results('type' => 'STyp') do it { expect(subject.type).to eql('STyp') } end
@@ -28,6 +28,10 @@ describe Plaid::Account do
 
     with_results('numbers' => {}) do
       it { expect(subject.numbers).to eql({}) }
+    end
+
+    with_results({}) do
+      it { expect(subject.name).to eq nil } # doesn't blow up if 'meta' is missing
     end
   end
 end


### PR DESCRIPTION
https://plaid.com/docs/#data-overview

We can see from the docs that there is no "name" attribute, but that the name is found under "meta.name". The current API responses match the documentation.