### PR TITLE
User: set pending_mfa_questions to hash

### DIFF
--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -176,7 +176,7 @@ module Plaid
         end
       end if res['transactions']
 
-      self.pending_mfa_questions = ''
+      self.pending_mfa_questions = {}
       self.information = Information.new(res['info']) if res['info']
       self.api_res = 'success'
 


### PR DESCRIPTION
If a response with MFA is received, it's a hash, so for data consistency, it's important to use an empty hash instead of a string if no MFA exists.