### PR TITLE
add support for MFA token refresh

### DIFF
--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -28,6 +28,17 @@ module Plaid
     end
 
     # API: public
+    # Sometimes, the /auth/step endpoint returns a 1215 "MFA access has changed"
+    # send a PATCH request to resolve this issue
+    def mfa_refresh(auth)
+      auth_path = permissions.last + '/step'
+      res = Connection.patch(auth_path, { mfa: auth, access_token: access_token, type: type })
+      self.accounts = []
+      self.transactions = []
+      update(res)
+    end
+
+    # API: public
     # Use this method to find out API levels available for this user
     def permit?(auth_level)
       self.permissions.include? auth_level

--- a/spec/plaid/models/user_spec.rb
+++ b/spec/plaid/models/user_spec.rb
@@ -75,6 +75,11 @@ describe Plaid::User do
 
       it { expect(new_mfa_user.accounts).not_to be_empty }
     end
+
+    context 'selects MFA method, delivers correct payload, refreshes MFA token' do
+      let(:user) { Plaid.add_user('auth', 'plaid_test', 'plaid_good', 'us') }
+      it { expect(user.mfa_refresh('tomato').accounts).not_to be_empty }
+    end
   end
 
   context 'when authenticating' do


### PR DESCRIPTION
We are running into a situation where a user is submitting the correct MFA response, but we are getting a 1215 response (see https://github.com/plaid/support/blob/master/errors.md) from the Plaid API.  If we manually curl a PATCH request to the `/auth/step` endpoint at this point, we get a successful response.  This PR adds support for this flow to the gem.