### PR TITLE
Making it easier to pass in a hash of options when calling User::get()

### DIFF
--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -104,7 +104,7 @@ module Plaid
       when 'auth'
         update(Connection.post('auth/get', access_token: self.access_token))
       when 'connect'
-        payload = { access_token: self.access_token }.merge(options)
+        payload = { access_token: self.access_token }.merge({options: options.to_json})
         update(Connection.post('connect/get', payload))
       when 'info'
         update(Connection.secure_get('info', self.access_token))


### PR DESCRIPTION
I couldn't figure out why my pending transactions weren't loading when calling `@user.get_connect(pending: true})`

Turns out I needed to pass in the options key with the options hash, which didn't make much sense to me. I ended up getting it to work using `@user.get_connect({options: { pending: true }.to_json})`

With this change, you'll be able to pass in options in a more intuitive manner using `@user.get_connect({pending: true})`