### PR TITLE
Clear existing transactions before setting them on the user

### DIFF
--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -164,14 +164,18 @@ module Plaid
         end
       end if res['accounts']
 
-      res['transactions'].each do |transaction|
-        if self.transactions.any? { |t| t == transaction['_id'] }
-          owned_transaction = self.transactions.find { |h| h == transaction['_id'] }
-          owned_transaction.new(transaction)
-        else
-          self.transactions << Transaction.new(transaction)
+      if res['transactions']
+        self.transactions = [] # clear existing transactions
+
+        res['transactions'].each do |transaction|
+          if self.transactions.any? { |t| t == transaction['_id'] }
+            owned_transaction = self.transactions.find { |h| h == transaction['_id'] }
+            owned_transaction.new(transaction)
+          else
+            self.transactions << Transaction.new(transaction)
+          end
         end
-      end if res['transactions']
+      end
 
       self.pending_mfa_questions = {}
       self.information = Information.new(res['info']) if res['info']

--- a/lib/plaid/models/user.rb
+++ b/lib/plaid/models/user.rb
@@ -50,8 +50,8 @@ module Plaid
 
     # API: public
     # Use this method to delete a user from the Plaid API
-    def delete_user
-      Connection.delete('info', { access_token: self.access_token })
+    def delete_user(auth_level='info')
+      Connection.delete(auth_level, { access_token: self.access_token })
     end
 
     ### Internal build methods


### PR DESCRIPTION
I'm running into an issue where each time `user.get('connect')` is called the transactions are getting duplicated. I can't figure out a way to pass the `pending: true` option in with `Plaid.set_user()` so I have to call `user.get('connect', {options: {pending: true}.to_json})` after I set the user to grab the pending transactions. When this happens it's duplicating the transactions

You can verify this using:
```
2.1.2 :007 > user = Plaid.set_user(exchangeTokenResponse.access_token, ['connect'])
2.1.2 :008 > user.transactions.size
 => 16
2.1.2 :009 > user.get('connect')
2.1.2 :010 > user.transactions.size
 => 32
2.1.2 :011 > user.get('connect')
2.1.2 :012 > user.transactions.size
 => 48
```

This change clears the existing transactions by setting `self.transactions = []` before setting the transactions from the response. 

I'm not sure if the `if self.transactions.any? { |t| t == transaction['_id'] }` check is supposed to be doing this, but it doesn't seem to be working. I think just clearing the transactions will be faster too, since you won't have to search through the existing transactions to see if each transaction in the response already exists. 