### PR TITLE
Updating exchange_token method to reflect API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
   - 2.1.3
+sudo: false
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ruby bindings for the Plaid API
 
 This version is a beta version that contains failing tests for the new 'info' endpoint. While these have been tested individually on real accounts the tests here will fail with the test accounts supplied. These will be updated soon with test credentials.
 
-Latest stable version: **1.7.0**
+Latest stable version: **1.7.1**
 
 This version removes the need to use 'type' in each additional call.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Plaid.config do |p|
 end
 
 # Exchange a Link public_token for a Plaid access_token
-exchangeTokenResponse = Plaid.exchange_token('test,chase,connected')
+exchangeTokenResponse = Plaid.exchange_token('test,chase,connected', 'account_id')
 
 # Use the API access_token to initialize a user
 # Note: This example assumes you are using Link with the "auth" product

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Plaid.config do |p|
 end
 
 # Exchange a Link public_token for a Plaid access_token
+exchangeTokenResponse = Plaid.exchange_token('test,chase,connected')
+# Optionally include an account_id
 exchangeTokenResponse = Plaid.exchange_token('test,chase,connected', 'account_id')
 
 # Use the API access_token to initialize a user

--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -35,8 +35,9 @@ module Plaid
     # Exchange a Plaid Link public_token for a Plaid access_token
     # Required parameters:
     #   public_token
-    def exchange_token(public_token)
-      payload = { public_token: public_token }
+    #   account_id
+    def exchange_token(public_token, account_id)
+      payload = { public_token: public_token, account_id: account_id }
 
       res = Connection.post('exchange_token', payload)
       ExchangeTokenResponse.new(res)

--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -35,9 +35,11 @@ module Plaid
     # Exchange a Plaid Link public_token for a Plaid access_token
     # Required parameters:
     #   public_token
-    #   account_id
-    def exchange_token(public_token, account_id)
-      payload = { public_token: public_token, account_id: account_id }
+    #   account_id (optional)
+    def exchange_token(public_token, account_id = nil)
+      payload = { public_token: public_token }
+      # include the account id, if set
+      payload[:account_id] = account_id if account_id
 
       res = Connection.post('exchange_token', payload)
       ExchangeTokenResponse.new(res)

--- a/lib/plaid/models/exchange_token_response.rb
+++ b/lib/plaid/models/exchange_token_response.rb
@@ -1,9 +1,11 @@
 module Plaid
   class ExchangeTokenResponse
     attr_accessor :access_token
+    attr_accessor :stripe_bank_account_token
 
     def initialize(fields = {})
       @access_token = fields['access_token']
+      @stripe_bank_account_token = fields['stripe_bank_account_token']
     end
   end
 end

--- a/lib/plaid/version.rb
+++ b/lib/plaid/version.rb
@@ -1,3 +1,3 @@
 module Plaid
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -201,7 +201,7 @@ describe Plaid do
   end
 
   describe '.exchange_token' do
-    subject { Plaid.exchange_token('test,chase,connected') }
+    subject { Plaid.exchange_token('test,chase,connected', 'QPO8Jo8vdDHMepg41PBwckXm4KdK1yUdmXOwK') }
 
     it { expect(subject.access_token).to eql('test_chase') }
   end


### PR DESCRIPTION
The `/exchange_token` endpoint now takes two parameters.

cc @michaelckelly 