### PR TITLE
Show descritive message for errors

### DIFF
--- a/lib/plaid/errors.rb
+++ b/lib/plaid/errors.rb
@@ -2,11 +2,15 @@ module Plaid
   class PlaidError < StandardError
     attr_reader :code
     attr_reader :resolve
-    
+
     def initialize(code, message, resolve)
       super(message)
       @code = code
       @resolve = resolve
+    end
+
+    def to_s
+      "(Code #{code}) #{super}\n#{resolve}"
     end
   end
 

--- a/spec/plaid/config_spec.rb
+++ b/spec/plaid/config_spec.rb
@@ -56,12 +56,12 @@ describe 'Plaid.config' do
   context 'has invalid dev keys' do
     let(:secret) { 'test_bad' }
     let(:environment_location) { dev_url }
-    it { expect { user }.to raise_error(Plaid::Unauthorized, 'secret or client_id invalid') }
+    it { expect { user }.to raise_error(Plaid::Unauthorized, /secret or client_id invalid/) }
   end
 
   context 'has invalid production keys' do
     let(:secret) { 'test_bad' }
     let(:environment_location) { prod_url }
-    it { expect { user }.to raise_error(Plaid::Unauthorized, 'secret or client_id invalid') }
+    it { expect { user }.to raise_error(Plaid::Unauthorized, /secret or client_id invalid/) }
   end
 end

--- a/spec/plaid/connection_spec.rb
+++ b/spec/plaid/connection_spec.rb
@@ -26,27 +26,27 @@ describe Plaid::Connection do
 
     it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:post, stub_url).to_return(status: 400, body: bad_req_response)
-      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::BadRequest, /invalid credentials/)
     end
 
     it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:post, stub_url).to_return(status: 401, body: unauth_response)
-      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::Unauthorized, /bad access_token/)
     end
 
     it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:post, stub_url).to_return(status: 402, body: req_fail_response)
-      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::RequestFailed, /invalid credentials/)
     end
 
     it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:post, stub_url).to_return(status: 404, body: req_not_found)
-      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::NotFound, "product not found")
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::NotFound, /product not found/)
     end
 
     it "throws a Plaid::ServerError on empty response" do
       stub = stub_request(:post, stub_url).to_return(status: 504, body: '')
-      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::ServerError, '')
+      expect { Plaid::Connection.post("testing") }.to raise_error(Plaid::ServerError)
     end
   end
 
@@ -71,22 +71,22 @@ describe Plaid::Connection do
 
     it "throws 404 for 1301 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1301, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
-      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, /Doesn't matter/)
     end
 
     it "throws 404 for 1401 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1401, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
-      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, /Doesn't matter/)
     end
 
     it "throws 404 for 1501 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1501, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
-      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, /Doesn't matter/)
     end
 
     it "throws 404 for 1601 code" do
       stub = stub_request(:get, stub_url).to_return({:body => {"code" => 1601, "message" => "Doesn't matter", "resolve" => "Yep."}.to_json})
-      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, "Doesn't matter")
+      expect { Plaid::Connection.get("testing")}.to raise_error(Plaid::NotFound, /Doesn't matter/)
     end
 
   end
@@ -112,27 +112,27 @@ describe Plaid::Connection do
 
     it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:get, stub_url).to_return(status: 400, body: bad_req_response)
-      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::BadRequest, /invalid credentials/)
     end
 
     it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:get, stub_url).to_return(status: 401, body: unauth_response)
-      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::Unauthorized, /bad access_token/)
     end
 
     it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:get, stub_url).to_return(status: 402, body: req_fail_response)
-      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::RequestFailed, /invalid credentials/)
     end
 
     it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:get, stub_url).to_return(status: 404, body: req_not_found)
-      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::NotFound, "product not found")
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::NotFound, /product not found/)
     end
 
     it "throws a Plaid::ServerError on empty response" do
       stub = stub_request(:get, stub_url).to_return(status: 504, body: '')
-      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::ServerError, '')
+      expect { Plaid::Connection.secure_get("testing", "test_wells") }.to raise_error(Plaid::ServerError)
     end
   end
 
@@ -157,27 +157,27 @@ describe Plaid::Connection do
 
     it "throws Plaid::BadRequest on 400 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 400, body: bad_req_response)
-      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::BadRequest, "invalid credentials")
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::BadRequest, /invalid credentials/)
     end
 
     it "throws Plaid::Unauthorized on 401 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 401, body: unauth_response)
-      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::Unauthorized, "bad access_token")
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::Unauthorized, /bad access_token/)
     end
 
     it "throws Plaid::RequestFailed on 402 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 402, body: req_fail_response)
-      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::RequestFailed, "invalid credentials")
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::RequestFailed, /invalid credentials/)
     end
 
     it "throws a Plaid::NotFound on 404 response" do
       stub = stub_request(:patch, stub_url).to_return(status: 404, body: req_not_found)
-      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::NotFound, "product not found")
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::NotFound, /product not found/)
     end
 
     it "throws a Plaid::ServerError on empty response" do
       stub = stub_request(:patch, stub_url).to_return(status: 504, body: '')
-      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::ServerError, '')
+      expect { Plaid::Connection.patch("testing") }.to raise_error(Plaid::ServerError)
     end
   end
 

--- a/spec/plaid/error_spec.rb
+++ b/spec/plaid/error_spec.rb
@@ -1,10 +1,15 @@
 describe Plaid::PlaidError do
   describe "#new" do
-    it "allows code, message and resolution" do
-      error = Plaid::PlaidError.new 1, "testing", "fix it"
-      expect(error.code).to eq(1)
-      expect(error.message).to eq("testing")
-      expect(error.resolve).to eq("fix it")
+    it "displays code, message, and resolution when thrown" do
+      error = described_class.new(
+        1200,
+        "invalid credentials",
+        "The username or password provided is not correct"
+      )
+
+      expect(error.message).to include("1200")
+      expect(error.message).to include("invalid credentials")
+      expect(error.message).to include("The username or password provided is not correct")
     end
   end
 end

--- a/spec/plaid/models/category_spec.rb
+++ b/spec/plaid/models/category_spec.rb
@@ -10,7 +10,7 @@ describe Plaid::Category do
   end
 
   context 'when category is not found' do
-    it { expect { Plaid.category('dumb_cat') }.to raise_error(Plaid::NotFound, 'unable to find category') }
+    it { expect { Plaid.category('dumb_cat') }.to raise_error(Plaid::NotFound, /unable to find category/) }
   end
 
 end

--- a/spec/plaid/models/institution_spec.rb
+++ b/spec/plaid/models/institution_spec.rb
@@ -14,6 +14,6 @@ describe Plaid::Institution do
   end
 
   context 'when institution is not found' do
-    it { expect { Plaid.institution('dumb_bank') }.to raise_error(Plaid::NotFound, 'unable to find institution') }
+    it { expect { Plaid.institution('dumb_bank') }.to raise_error(Plaid::NotFound, /unable to find institution/) }
   end
 end

--- a/spec/plaid/models/user_spec.rb
+++ b/spec/plaid/models/user_spec.rb
@@ -37,7 +37,7 @@ describe Plaid::User do
     context 'enters incorrect credentials for MFA auth' do
       let(:mfa_user) { user.mfa_authentication('tomato') }
       let(:mfa_bad)  { mfa_user; Plaid.add_user('connect', 'plaid_test', 'plaid_good', 'bofa') }
-      it { expect { mfa_bad.mfa_authentication('bad') }.to raise_error(Plaid::RequestFailed, 'invalid mfa') }
+      it { expect { mfa_bad.mfa_authentication('bad') }.to raise_error(Plaid::RequestFailed, /invalid mfa/) }
     end
 
     context 'requests list of MFA credentials' do
@@ -143,7 +143,7 @@ describe Plaid::User do
     let(:info_user) { Plaid.add_user('info', 'plaid_test', 'plaid_good', 'wells') }
 
     context 'updates information correctly' do
-      it { expect { subject.get_info }.to raise_error(Plaid::Unauthorized, 'client_id missing') }
+      it { expect { subject.get_info }.to raise_error(Plaid::Unauthorized, /client_id missing/) }
     end
   end
 

--- a/spec/plaid_spec.rb
+++ b/spec/plaid_spec.rb
@@ -89,12 +89,12 @@ describe Plaid do
 
         context 'using incorrect password' do
           let(:password) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
 
         context 'using incorrect username' do
           let(:username) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
       end
 
@@ -103,12 +103,12 @@ describe Plaid do
 
         context 'using incorrect password' do
           let(:password) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
 
         context 'using incorrect username' do
           let(:username) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
       end
 
@@ -117,12 +117,12 @@ describe Plaid do
 
         context 'using incorrect password' do
           let(:password) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
 
         context 'using incorrect username' do
           let(:username) { 'plaid_bad' }
-          it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid credentials') }
+          it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid credentials/) }
         end
       end
     end
@@ -140,7 +140,7 @@ describe Plaid do
 
       context 'using incorrect PIN' do
         let(:pin) { '0000' }
-        it { expect { user }.to raise_error(Plaid::RequestFailed, 'invalid pin') }
+        it { expect { user }.to raise_error(Plaid::RequestFailed, /invalid pin/) }
       end
     end
 


### PR DESCRIPTION
Currently, when an error is thrown, the error message is only the
`message` from the API response, which is not descriptive enough to
perceive an error resolution path.

Resolution: Add the `code` and `resolve` to `PlaidError#to_s` so that an error can
be looked up in the docs by `code`

As a side effect, change `raise_error` matches to regexes instead of
strings to assert that the message includes the value instead of exactly
equaling the value