### PR TITLE
Extending Net::ReadTimeout to 2 minutes

### DIFF
--- a/lib/plaid/connection.rb
+++ b/lib/plaid/connection.rb
@@ -5,7 +5,7 @@ require 'uri'
 module Plaid
   class Connection
 
-    WAIT_TIMEOUT = 120
+    WAIT_TIMEOUT = 300
 
     class << self
       # API: semi-private

--- a/lib/plaid/version.rb
+++ b/lib/plaid/version.rb
@@ -1,3 +1,3 @@
 module Plaid
-  VERSION = '1.7.2'
+  VERSION = '1.7.3'
 end


### PR DESCRIPTION
After many timeout errors, Plaid support recommended I raise our timeout threshold to 2 minutes. After raising it on our server I noticed the gem timing out. It seems Net::ReadTimeout default is 60 seconds.