### PR TITLE
Support :production in Plaid::Client#env=

### DIFF
--- a/lib/plaid/client.rb
+++ b/lib/plaid/client.rb
@@ -14,12 +14,14 @@ module Plaid
 
     # Public: Set Plaid environment to use.
     #
-    # env - The Symbol (:tartan, :api), or a full String URL like
+    # env - The Symbol (:tartan, :production), or a full String URL like
     #       'https://tartan.plaid.com'.
     def env=(env)
       case env
-      when :tartan, :api
-        @env = "https://#{env}.plaid.com/"
+      when :tartan
+        @env = 'https://tartan.plaid.com/'
+      when :production
+        @env = 'https://api.plaid.com/'
       when String
         begin
           URI.parse(env)
@@ -27,20 +29,20 @@ module Plaid
         rescue
           raise ArgumentError, 'Invalid URL in Plaid::Client.env' \
                                " (#{env.inspect}). " \
-                               'Specify either Symbol (:tartan, :api), or a ' \
-                               "full URL, like 'https://tartan.plaid.com'"
+                               'Specify either Symbol (:tartan, :production),' \
+                               " or a full URL, like 'https://tartan.plaid.com'"
         end
       else
         raise ArgumentError, 'Invalid value for Plaid::Client.env' \
                              " (#{env.inspect}): " \
-                             'must be :tartan, :api, or a full URL, ' \
+                             'must be :tartan, :production, or a full URL, ' \
                              "e.g. 'https://tartan.plaid.com'"
       end
     end
 
     # Public: Construct a Client instance.
     #
-    # env       - The Symbol (:tartan, :api), or a full String URL like
+    # env       - The Symbol (:tartan, :production), or a full String URL like
     #             'https://tartan.plaid.com'.
     # client_id - The String Plaid account client ID to authenticate requests.
     # secret    - The String Plaid account secret to authenticate requests.

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -9,7 +9,7 @@ class PlaidClientTest < MiniTest::Test
     assert_equal 'https://tartan.plaid.com/', client.env
 
     client2 = Plaid::Client.new
-    client2.env = :api
+    client2.env = :production
 
     assert_equal 'https://api.plaid.com/', client2.env
   end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -10,7 +10,7 @@ class PlaidConfigTest < MiniTest::Test
     assert_equal 'https://tartan.plaid.com/', Plaid.client.env
 
     Plaid.config do |p|
-      p.env = :api
+      p.env = :production
     end
 
     assert_equal 'https://api.plaid.com/', Plaid.client.env


### PR DESCRIPTION
`:api` was replaced with `:production`.