### PR TITLE
User#mfa_step signature change and minor readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ end
 user = Plaid::User.create(:connect, 'wells', 'plaid_test', 'plaid_good')
 ```
 
-This call will do a `POST /connect`. The response will contain account information and transactions 
+This call will do a `POST /connect`. The response will contain account information and transactions
 for last 30 days, which you can find in `user.accounts` and `user.initial_transactions`, accordingly.
 
 If the authentication requires a pin, you can pass it as a named parameter:
 
 ```ruby
-user = Plaid::User.create(:income, 'usaa', 'plaid_test', 'plaid_good', 'wells', pin: '1234')
+user = Plaid::User.create(:income, 'usaa', 'plaid_test', 'plaid_good', pin: '1234')
 ```
 
 To add options such as `login_only` or `webhook`, use `options` argument:
 
 ```ruby
-user = Plaid::User.create(:connect, 'wells', 'plaid_test', 'plaid_good', 
+user = Plaid::User.create(:connect, 'wells', 'plaid_test', 'plaid_good',
                           options: { login_only: true, webhook: 'https://example.org/callbacks/plaid')
 ```
 
@@ -126,7 +126,7 @@ If MFA is requested by the financial institution, the `User.create` call would b
 a bit differently:
 
 ```ruby
-user = Plaid::User.create(:auth, 'wells', 'plaid_test', 'plaid_good') 
+user = Plaid::User.create(:auth, 'wells', 'plaid_test', 'plaid_good')
 
 user.accounts   #=> nil
 user.mfa?       #=> true
@@ -145,16 +145,16 @@ user.mfa        #=> nil
 user.accounts   #=> [<Plaid::Account ...>, ...]
 ```
 
-The code-based MFA workflow is similar. Basically you need to call `user.mfa_step(...)` 
+The code-based MFA workflow is similar. Basically you need to call `user.mfa_step(...)`
 until `user.mfa?` becomes false.
 
 ### Obtaining user-related data
 
-If you have a live `User` instance, you can use following methods 
+If you have a live `User` instance, you can use following methods
 (independent of instance's current product):
 
 * `user.transactions(...)`. Makes a `/connect/get` request.
-* `user.auth(sync: false)`. Makes an `/auth/get` request. 
+* `user.auth(sync: false)`. Makes an `/auth/get` request.
 * `user.info(sync: false)`. Makes an `/info/get` request.
 * `user.income(sync: false)`. Makes an `/income/get` request.
 * `user.risk(sync: false)`. Makes an `/risk/get` request.
@@ -176,7 +176,7 @@ loaded. Otherwise cached information will be returned:
 
 ```ruby
 user = User.load(:auth, 'access_token')   # Just set the token
-user.auth                                 # POST /auth/get 
+user.auth                                 # POST /auth/get
 user.auth                                 # No POST, return cached info
 user.auth(sync: true)                     # POST /auth/get again
 ```
@@ -207,11 +207,11 @@ res  = Plaid::LongTailInstitution.search(query: 'c')         # Lookup by name
 
 ### Custom clients
 
-It's possible to use several Plaid environments and/or credentials in one app by 
+It's possible to use several Plaid environments and/or credentials in one app by
 explicit instantiation of `Plaid::Client`:
 
 ```ruby
-# Configuring the global client (Plaid.client) which is used by default 
+# Configuring the global client (Plaid.client) which is used by default
 Plaid.config do |p|
   p.client_id = 'client_id_1'
   p.secret = 'secret_1'

--- a/lib/plaid/user.rb
+++ b/lib/plaid/user.rb
@@ -163,13 +163,34 @@ module Plaid
     # send_method - The Hash with code send method information.
     #               E.g. { type: 'phone' } or { mask: '123-...-4321' }.
     #               Default is first available email.
+    # options     - the Hash options (default: {}):
+    #               :list       - The Boolean flag which would request the
+    #                             available send methods if the institution
+    #                             requires code-based MFA credential (default:
+    #                             false).
+    #               :webhook    - The String webhook URL. Used with :connect,
+    #                             :income, and :risk products (default: nil).
+    #               :pending    - The Boolean flag requesting to return
+    #                             pending transactions. Used with :connect
+    #                             product (default: false).
+    #               :login_only - The Boolean option valid for initial
+    #                             authentication only. If set to false, the
+    #                             initial request will return transaction data
+    #                             based on the start_date and end_date.
+    #               :start_date - The start Date from which to return
+    #                             transactions (default: 30 days ago).
+    #               :end_date   - The end Date to which transactions
+    #                             will be collected (default: today).
     #
     # Returns true if whole MFA process is completed, false otherwise.
-    def mfa_step(info = nil, send_method: nil)
+    def mfa_step(info = nil, send_method: nil, options: nil)
       payload = { access_token: access_token }
       payload[:mfa] = info if info
-      payload[:send_method] = MultiJson.dump(send_method) if send_method
-
+      if options || send_method
+        options = {} unless options
+        options[:send_method] = send_method if send_method
+        payload[:options] = MultiJson.dump(options)
+      end
       conn = Connector.new(product, :step, auth: true)
       response = conn.post(payload)
 

--- a/test/test_user.rb
+++ b/test/test_user.rb
@@ -156,7 +156,7 @@ module ProductTests
                   { mask: 'SafePass Card', type: 'card' }], user.mfa)
 
     # Request to send code
-    body = credentials.merge(send_method: '{"type":"phone"}')
+    body = credentials.merge(options: '{"send_method":{"type":"phone"}}')
     stub_api :post, "#{product}/step", body: body, response: :mfa_code_sent,
                                        status: 201
 


### PR DESCRIPTION
Not sure what happened with that last PR... Anyway, to recap:

The send_method parameter needs to go into the options field according to the Plaid docs. Also, there was no access to the options param for adding things like login_only and webhook so I added an extra argument for it. And a minor readme typo fix. And as an aside, I couldn't decide whether to merge the send_method param into options, so I just left it as two parameters in case it would break some reliance on send_method in the rest of the code/tests.