### PR TITLE
Relax multi_json version dependency

### DIFF
--- a/plaid.gemspec
+++ b/plaid.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'multi_json', '~> 1.11.3'
+  spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Using `~> 1.0` per [multi_json README](https://github.com/intridea/multi_json#versioning).

Resolves #117