### PR TITLE
Updating method parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ user = Plaid::User.exchange_token('public_token')   # bound to :connect product
 With more options:
 
 ```ruby
-user2 = Plaid::User.exchange_token('public_token', account_id: '...', product: :auth)
+user2 = Plaid::User.exchange_token('public_token', 'account_id', product: :auth)
 ```
 
 If you want to [move money via Stripe's ACH


### PR DESCRIPTION
The `exchange_token` method accepts a normal optional
parameter for the `account_id` instead of a keyword parameter
like the README indicates. Updating to match source code.