### PR TITLE
Add _reference_number to Transaction class

### DIFF
--- a/lib/plaid/transaction.rb
+++ b/lib/plaid/transaction.rb
@@ -74,6 +74,10 @@ module Plaid
     # E.g. "13005000".
     attr_reader :category_id
 
+    # Public: A String attribute that is used by the bank/payment
+    # processor to identify transactions — where applicable.
+    attr_reader :reference_number
+
     # Public: The String ID of a posted transaction's associated
     # pending transaction - where applicable.
     attr_reader :pending_transaction_id
@@ -91,6 +95,7 @@ module Plaid
       @meta = Plaid.symbolize_hash(fields['meta'])
       @location = (@meta && @meta[:location]) || {}
       @pending = fields['pending']
+      @reference_number = fields['_reference_number']
       @pending_transaction_id = fields['_pendingTransaction']
       @score = Plaid.symbolize_hash(fields['score'])
 

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -25,6 +25,7 @@ class PlaidTransactionTest < MiniTest::Test
     assert_equal '21012002', trans.category_id
     assert_equal 'Nw83eMkqVXSaZvM17aVqtoOwLo1nOAipXeZ74',
                  trans.pending_transaction_id
+    assert_equal '1000001', trans.reference_number
   end
 
   def test_pending
@@ -58,6 +59,7 @@ class PlaidTransactionTest < MiniTest::Test
           'city' => 'San Francisco',
           'state' => 'CA' } },
       'pending' => pending,
+      '_reference_number' => '1000001',
       '_pendingTransaction' => 'Nw83eMkqVXSaZvM17aVqtoOwLo1nOAipXeZ74',
       'type' => { 'primary' => 'special' },
       'category' => %w(Transfer Withdrawal ATM),


### PR DESCRIPTION
Adds support for _reference_number, a transaction field specified in https://plaid.com/docs/api/#data-overview
