### PR TITLE
MFA Update PATCH fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ user.accounts   #=> [<Plaid::Account ...>, ...]
 The code-based MFA workflow is similar. Basically you need to call `user.mfa_step(...)`
 until `user.mfa?` becomes false.
 
+When updating credentials for a user use `user.mfa_step` but pass `{update: true}` as part of the options hash: `mfa_step('matz', send_method: send_method, options: {update: true})`. This way it will send a `PATCH` request instead of a `POST`.
+
 ### Obtaining user-related data
 
 If you have a live `User` instance, you can use following methods

--- a/lib/plaid/user.rb
+++ b/lib/plaid/user.rb
@@ -212,7 +212,9 @@ module Plaid
       conn = Connector.new(product, :step, auth: true)
 
       # Use PATCH if the {update: true} was passed in the options Hash
-      response = if options && options[:update]
+      use_patch = (options && options[:update].present?) ? options[:update] : @mfa_patch
+
+      response = if use_patch
                    conn.patch(payload)
                  else
                    conn.post(payload)
@@ -278,6 +280,9 @@ module Plaid
       end
 
       parse_response(resp)
+
+      # A note for User#mfa_step to send PATCH request too
+      @mfa_patch = true
 
       self
     end

--- a/lib/plaid/user.rb
+++ b/lib/plaid/user.rb
@@ -212,7 +212,7 @@ module Plaid
       conn = Connector.new(product, :step, auth: true)
 
       # Use PATCH if the {update: true} was passed in the options Hash
-      use_patch = (options && options[:update].present?) ? options[:update] : @mfa_patch
+      use_patch = (options && !options[:update].nil?) ? options[:update] : @mfa_patch
 
       response = if use_patch
                    conn.patch(payload)

--- a/lib/plaid/user.rb
+++ b/lib/plaid/user.rb
@@ -212,7 +212,7 @@ module Plaid
       conn = Connector.new(product, :step, auth: true)
 
       # Use PATCH if the {update: true} was passed in the options Hash
-      response = if options[:update]
+      response = if options && options[:update]
                    conn.patch(payload)
                  else
                    conn.post(payload)

--- a/lib/plaid/user.rb
+++ b/lib/plaid/user.rb
@@ -211,8 +211,8 @@ module Plaid
       end
       conn = Connector.new(product, :step, auth: true)
 
-      # Use PATCH if we are in context of User#update.
-      response = if @mfa_patch
+      # Use PATCH if the {update: true} was passed in the options Hash
+      response = if options[:update]
                    conn.patch(payload)
                  else
                    conn.post(payload)
@@ -278,9 +278,6 @@ module Plaid
       end
 
       parse_response(resp)
-
-      # A note for User#mfa_step to send PATCH request too
-      @mfa_patch = true
 
       self
     end


### PR DESCRIPTION
When updating credentials for a user use `user.mfa_step` but pass `{update: true}` as part of the options hash: `mfa_step('matz', send_method: send_method, options: {update: true})`. This way it will send a `PATCH` request instead of a `POST`.