### PR TITLE
Fix configuration example

### DIFF
--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -31,11 +31,12 @@ module Plaid
     #
     # Examples
     #
+    #   Plaid.read_timeout = 300   # it's 5 minutes, yay!       
+    #
     #   Plaid.configure do |p|
     #     p.client_id = 'Plaid provided client ID here'
     #     p.secret = 'Plaid provided secret key here'
     #     p.env = :tartan
-    #     p.read_timeout = 300   # it's 5 minutes, yay!
     #   end
     #
     # Returns nothing.


### PR DESCRIPTION
Just a doc fix based on the current read_timeout configuration behavior. 

I was playing around with moving the read_timeout configuration to the client as the example suggested it was, but I don't know if there's a compelling reason to do so at this point, and it doesn't preserve the non custom client behavior. This isn't backwards compatible, but could be made so if this is preferred:  https://github.com/TaylorBoudreau/plaid-ruby/commit/f984daeb116411d956bef8b36284b050a8ffad3f