### PR TITLE
Correct systax error when trying to publish on heroku

### DIFF
--- a/lib/plaid/client.rb
+++ b/lib/plaid/client.rb
@@ -94,7 +94,7 @@ module Plaid
     # client_id  - The String Plaid account client ID to authenticate requests
     # secret     - The String Plaid account secret to authenticate requests
     # public_key - The String Plaid account public key to authenticate requests
-    def initialize(env:, client_id:, secret:, public_key:)
+    def initialize(env, client_id, secret, public_key)
       @env        = env_map(env)
       @client_id  = client_id
       @secret     = secret


### PR DESCRIPTION
When publishing on heroku production enviroment is getting this error:

remote: rake aborted!
remote: /tmp/build_fb51757837926a2074019e05fe8071df/vendor/bundle/ruby/2.0.0/gems/plaid-4.0.0/lib/plaid/client.rb:97: syntax error, unexpected ','
remote:     def initialize(env:, client_id:, secret:, public_key:)
remote:                         ^
remote: /tmp/build_fb51757837926a2074019e05fe8071df/vendor/bundle/ruby/2.0.0/gems/plaid-4.0.0/lib/plaid/client.rb:137: syntax error, unexpected keyword_end, expecting end-of-input
