### PR TITLE
Implement the options parameter for institutions#get

### DIFF
--- a/lib/plaid/products/institutions.rb
+++ b/lib/plaid/products/institutions.rb
@@ -10,13 +10,15 @@ module Plaid
     # Does a POST /institutions/get call pulls a list of supported Plaid institutions
     # with the information for each institution
     #
-    # count  - Amount of institutions to pull
-    # offset - Offset to start pulling institutions
+    # count   - Amount of institutions to pull
+    # offset  - Offset to start pulling institutions
+    # options - Options for filtering institutions
     #
     # Returns a parsed JSON of listed institution information
-    def get(count:, offset:)
+    def get(count:, offset:, options: nil)
       payload = { count: count,
                   offset: offset }
+      payload[:options] = options unless options.nil?
       @client.post_with_auth('institutions/get', payload)
     end
 

--- a/lib/plaid/products/institutions.rb
+++ b/lib/plaid/products/institutions.rb
@@ -19,6 +19,7 @@ module Plaid
       payload = { count: count,
                   offset: offset }
       payload[:options] = options unless options.nil?
+
       @client.post_with_auth('institutions/get', payload)
     end
 

--- a/test/test_institutions.rb
+++ b/test/test_institutions.rb
@@ -7,7 +7,7 @@ class PlaidInstitutionsTest < PlaidTest
   end
 
   def test_get
-    response = @client.institutions.get(count: 3, offset: 1)
+    response = @client.institutions.get(count: 3, offset: 1, options: {products: ['transactions']})
     assert_equal(3, response['institutions'].length)
   end
 

--- a/test/test_institutions.rb
+++ b/test/test_institutions.rb
@@ -7,6 +7,11 @@ class PlaidInstitutionsTest < PlaidTest
   end
 
   def test_get
+    response = @client.institutions.get(count: 3, offset: 1)
+    assert_equal(3, response['institutions'].length)
+  end
+
+  def test_get_with_options
     response = @client.institutions.get(count: 3, offset: 1, options: {products: ['transactions']})
     assert_equal(3, response['institutions'].length)
   end


### PR DESCRIPTION
According to the [documentation](https://plaid.com/docs/api/#all-institutions), this feature should be supported. However, in practice, it's not.

I have added the extra `options` keyword argument to the `institutions#get` method, as well as modified the test case to include the extra argument.