### PR TITLE
endpoints for creating Apex and Dwolla processor_tokens

### DIFF
--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -22,6 +22,29 @@ module Plaid
     end
   end
 
+  class ProcessorToken
+    def initialize(client, sub_product)
+      @client = client
+      @sub_product = sub_product
+    end
+
+    # Public: Creates an processor token from an access_token for a specific sub-product.
+    #
+    # Does a POST /processor/[sub_product]/processor_token/create call which can
+    # be used to generate a processor token for a given account ID.
+    #
+    # access_token - access_token to create a public token for
+    # account_id - ID of the account to create a processor token for
+    #
+    # Returns a parsed JSON containing a processor token
+    def create(access_token, account_id)
+      payload = { access_token: access_token,
+                  account_id: account_id }
+      @client.post_with_auth("processor/#{@sub_product}/processor_token/create",
+                             payload)
+    end
+  end
+
   # Public: Class used to call the Stripe sub-product.
   class Stripe
     # Public: Memoized class instance to make requests from Plaid::BankAccountToken
@@ -34,11 +57,45 @@ module Plaid
     end
   end
 
+  # Public: Class used to call the Apex sub-product.
+  class Apex
+    # Public: Memoized class instance to make requests from Plaid::ProcessorToken
+    def processor_token
+      @processor_token ||= Plaid::ProcessorToken.new(@client, :apex)
+    end
+
+    def initialize(client)
+      @client = client
+    end
+  end
+
+  # Public: Class used to call the Dwolla sub-product.
+  class Dwolla
+    # Public: Memoized class instance to make requests from Plaid::ProcessorToken
+    def processor_token
+      @processor_token ||= Plaid::ProcessorToken.new(@client, :dwolla)
+    end
+
+    def initialize(client)
+      @client = client
+    end
+  end
+
   # Public: Class used to call the Processor product.
   class Processor
     # Public: Memoized class instance to make requests from Plaid::Stripe
     def stripe
       @stripe ||= Plaid::Stripe.new(@client)
+    end
+
+    # Public: Memoized class instance to make requests from Plaid::Apex
+    def apex
+      @apex ||= Plaid::Apex.new(@client)
+    end
+
+    # Public: Memoized class instance to make requests from Plaid::Dwolla
+    def dwolla
+      @dwolla ||= Plaid::Dwolla.new(@client)
     end
 
     def initialize(client)

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -18,4 +18,16 @@ class PlaidProcessorTest < PlaidTest
       @client.processor.stripe.bank_account_token.create(@access_token, BAD_STRING)
     end
   end
+
+  def test_apex_processor_token_create_invalid_account_id
+    assert_raises(Plaid::InvalidRequestError) do
+      @client.processor.apex.processor_token.create(@access_token, BAD_STRING)
+    end
+  end
+
+  def test_dwolla_processor_token_create_invalid_account_id
+    assert_raises(Plaid::InvalidRequestError) do
+      @client.processor.dwolla.processor_token.create(@access_token, BAD_STRING)
+    end
+  end
 end

--- a/test/vcr_cassettes/PlaidProcessorTest_test_apex_processor_token_create_invalid_account_id.yml
+++ b/test/vcr_cassettes/PlaidProcessorTest_test_apex_processor_token_create_invalid_account_id.yml
@@ -1,0 +1,371 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:44 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '422'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0",
+          "item": {
+            "available_products": [
+              "balance",
+              "credit_details",
+              "identity",
+              "income",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "QKmWazkpmDtnVnVPALzEC3PV16dKvnh3nE1yG",
+            "webhook": ""
+          },
+          "request_id": "AijPs"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:44 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/apex/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:45 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '202'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "aQa4X"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:45 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:46 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '46'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "deleted": true,
+          "request_id": "03Fj7"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:47 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:38 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '422'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "access-sandbox-85095658-5815-46f3-adf6-071548eaed57",
+          "item": {
+            "available_products": [
+              "balance",
+              "credit_details",
+              "identity",
+              "income",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "vPA1jzLqJGhj1myo3nB6iNEZWVGJb5hWzZPbl",
+            "webhook": ""
+          },
+          "request_id": "BpJbi"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:38 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/apex/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-85095658-5815-46f3-adf6-071548eaed57","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:39 GMT
+      server:
+      - nginx
+      content-length:
+      - '202'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "j1Os8"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:39 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-85095658-5815-46f3-adf6-071548eaed57","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:41 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '46'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "deleted": true,
+          "request_id": "wJNLl"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:41 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":null,"secret":null}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Wed, 22 Nov 2017 15:59:20 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '201'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "client_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "BMzZC"
+        }
+    http_version: 
+  recorded_at: Wed, 22 Nov 2017 15:59:20 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":null,"client_id":null,"secret":null}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Wed, 22 Nov 2017 15:59:20 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '201'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "client_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "qFDk0"
+        }
+    http_version: 
+  recorded_at: Wed, 22 Nov 2017 15:59:20 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/PlaidProcessorTest_test_dwolla_processor_token_create_invalid_account_id.yml
+++ b/test/vcr_cassettes/PlaidProcessorTest_test_dwolla_processor_token_create_invalid_account_id.yml
@@ -1,0 +1,371 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:44 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '422'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0",
+          "item": {
+            "available_products": [
+              "balance",
+              "credit_details",
+              "identity",
+              "income",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "QKmWazkpmDtnVnVPALzEC3PV16dKvnh3nE1yG",
+            "webhook": ""
+          },
+          "request_id": "AijPs"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:44 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/dwolla/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:45 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '202'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "aQa4X"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:45 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-57090a51-2368-49e2-87fb-1c1735832bb0","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Jul 2017 13:17:46 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '46'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "deleted": true,
+          "request_id": "03Fj7"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Jul 2017 13:17:47 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:38 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '422'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "access-sandbox-85095658-5815-46f3-adf6-071548eaed57",
+          "item": {
+            "available_products": [
+              "balance",
+              "credit_details",
+              "identity",
+              "income",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "vPA1jzLqJGhj1myo3nB6iNEZWVGJb5hWzZPbl",
+            "webhook": ""
+          },
+          "request_id": "BpJbi"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:38 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/dwolla/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-85095658-5815-46f3-adf6-071548eaed57","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:39 GMT
+      server:
+      - nginx
+      content-length:
+      - '202'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "j1Os8"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:39 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-85095658-5815-46f3-adf6-071548eaed57","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 10 Oct 2017 11:32:41 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '46'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "deleted": true,
+          "request_id": "wJNLl"
+        }
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 11:32:41 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/create
+    body:
+      encoding: UTF-8
+      string: '{"credentials":{"username":"user_good","password":"pass_good"},"institution_id":"ins_109508","initial_products":["auth"],"options":{},"client_id":null,"secret":null}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Wed, 22 Nov 2017 15:59:20 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '201'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "client_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "BMzZC"
+        }
+    http_version: 
+  recorded_at: Wed, 22 Nov 2017 15:59:20 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/delete
+    body:
+      encoding: UTF-8
+      string: '{"access_token":null,"client_id":null,"secret":null}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v4.0.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Wed, 22 Nov 2017 15:59:20 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '201'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "client_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "qFDk0"
+        }
+    http_version: 
+  recorded_at: Wed, 22 Nov 2017 15:59:20 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Not totally necessary, but might save some people a little time.

Usage would be:
`client.processor.apex.processor_token.create(access_token, account_id)`
and
`client.processor.dwolla.processor_token.create(access_token, account_id)`

Alternative (works without this PR) is:
```
client.post_with_auth(
  'processor/[sub-product]/processor_token/create',
  access_token: access_token,
  account_id: account_id
)
```