### PR TITLE
Add iso_currency_code and unofficial_currency_code properties to Balances

### DIFF
--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -100,6 +100,16 @@ module Plaid
       # :attr_reader:
       # Public: The Numeric limit (or nil).
       property :limit
+
+      ##
+      # :attr_reader:
+      # Public: The String available balance ISO currency code.
+      property :iso_currency_code
+
+      ##
+      # :attr_reader:
+      # Public: The String available balance unofficial currency code or (nil).
+      property :unofficial_currency_code
     end
 
     # Public: A representation of an account.


### PR DESCRIPTION
- Fix error: 
`Cannot coerce property "balances" from Hash to Plaid::Models::Balances: The property 'iso_currency_code' is not defined for Plaid::Models::Balances.`

This is done by adding the properties below to `Balances`.
-`iso_currency_code`
-`unofficial_currency_code`