### PR TITLE
Add options param to institutions.get_by_id

### DIFF
--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -538,6 +538,29 @@ module Plaid
       property :type
     end
 
+    # Public: A representation of Institution colors.
+    class InstitutionColors < BaseModel
+      ##
+      # :attr_reader:
+      # Public: A String containining the dark color hex for an institution.
+      property :dark
+
+      ##
+      # :attr_reader:
+      # Public: A String containining the darker color hex for an institution.
+      property :darker
+
+      ##
+      # :attr_reader:
+      # Public: A String containining the light color hex for an institution.
+      property :light
+
+      ##
+      # :attr_reader:
+      # Public: A String containining the primary color hex for an institution.
+      property :primary
+    end
+
     # Public: A representation of Institution.
     class Institution < BaseModel
       ##
@@ -603,9 +626,7 @@ module Plaid
       ##
       # :attr_reader:
       # Public: A hash of colors associated with this institution.
-      # E.g. {"dark"=>"#006692", "darker"=>"#00456f", "light"=>"#378fbe",
-      #       "primary"=>"#0075a3"}
-      property :colors
+      property :colors, coerce: InstitutionColors
 
       ##
       # :attr_reader:

--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -578,6 +578,90 @@ module Plaid
       # Public: The Array of String product names supported by this institution.
       # E.g. ["auth", "balance", "identity", "transactions"].
       property :products
+
+      ##
+      # :attr_reader:
+      # Public: The Brand name of this institution.
+      # E.g. "First Platypus Bank"
+      property :brand_name
+
+      ##
+      # :attr_reader:
+      # Public: The brand subheading of this institution.
+      property :brand_subheading
+
+      ##
+      # :attr_reader:
+      # Public: A string containing the name break of this institution.
+      property :name_break
+
+      ##
+      # :attr_reader:
+      # Public: ???
+      property :portal
+
+      ##
+      # :attr_reader:
+      # Public: A hash of colors associated with this institution.
+      # E.g. {"dark"=>"#006692", "darker"=>"#00456f", "light"=>"#378fbe",
+      #       "primary"=>"#0075a3"}
+      property :colors
+
+      ##
+      # :attr_reader:
+      # Public: A base64 string of the logo for this institution.
+      property :logo
+
+      ##
+      # :attr_reader:
+      # Public: A string representing the health status of this institution.
+      # E.g. "HEALTH_STATUS_GREEN
+      property :health_status
+
+      ##
+      # :attr_reader:
+      # Public: A string representing the legacy institution code of this
+      # institution.
+      # E.g. "ins_109508"
+      property :legacy_institution_code
+
+      ##
+      # :attr_reader:
+      # Public: A string representing the legacy institution type of this
+      # institution.
+      property :legacy_institution_type
+
+      ##
+      # :attr_reader:
+      # Public: A string representing the health status of the link to this
+      # institution.
+      # E.g. "HEALTH_STATUS_GREEN"
+      property :link_health_status
+
+      ##
+      # :attr_reader:
+      # Public: A string representing the url of this institution.
+      # institution.
+      # E.g. "https://www.plaid.com"
+      property :url
+
+      ##
+      # :attr_reader:
+      # Public: A string of the url to the account locked page for this
+      # institution.
+      property :url_account_locked
+
+      ##
+      # :attr_reader:
+      # Public: A string of the url to the account setup page for this
+      # institution.
+      property :url_account_setup
+
+      ##
+      # :attr_reader:
+      # Public: A string of the url to the forgotten password page for this
+      # institution.
+      property :url_forgotten_password
     end
 
     module MFA

--- a/lib/plaid/products/institutions.rb
+++ b/lib/plaid/products/institutions.rb
@@ -27,12 +27,16 @@ module Plaid
     # information for an institution by ID.
     #
     # institution_id - Specific institution id to fetch information for.
+    # options - Additional return options for fetching an institution.
     #
     # Returns a SingleInstitutionResponse instance.
-    def get_by_id(institution_id)
+    def get_by_id(institution_id, options: nil)
+      payload = { institution_id: institution_id }
+      payload[:options] = options unless options.nil?
+
       post_with_public_key 'institutions/get_by_id',
                            SingleInstitutionResponse,
-                           institution_id: institution_id
+                           payload
     end
 
     # Public: Get information about all available institutions matching your

--- a/test/test_institutions.rb
+++ b/test/test_institutions.rb
@@ -25,6 +25,14 @@ class PlaidInstitutionsTest < PlaidTest
     assert_equal(SANDBOX_INSTITUTION, response.institution.institution_id)
   end
 
+  def test_get_by_id_with_options
+    options = { include_display_data: true }
+    response = client.institutions.get_by_id(SANDBOX_INSTITUTION,
+                                             options: options)
+    assert_equal(SANDBOX_INSTITUTION_NAME,
+                 response['institution'][:brand_name])
+  end
+
   def test_get_by_id_invalid_parameters
     assert_raises(Plaid::InvalidInputError) do
       client.institutions.get_by_id(BAD_STRING)

--- a/test/vcr_cassettes/PlaidInstitutionsTest_test_get_by_id_with_options.yml
+++ b/test/vcr_cassettes/PlaidInstitutionsTest_test_get_by_id_with_options.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/institutions/get_by_id
+    body:
+      encoding: UTF-8
+      string: '{"institution_id":"ins_109508","options":{"include_display_data":true},"public_key":"PLAID_RUBY_PUBLIC_KEY"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v6.2.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2018-05-22'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 05 Jan 2019 02:23:56 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '513'
+      connection:
+      - close
+      plaid-version:
+      - '2018-05-22'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "institution": {
+            "brand_name": "First Platypus Bank",
+            "brand_subheading": null,
+            "colors": {
+              "dark": "#006692",
+              "darker": "#00456f",
+              "light": "#378fbe",
+              "primary": "#0075a3"
+            },
+            "credentials": [
+              {
+                "label": "Username",
+                "name": "username",
+                "type": "text"
+              },
+              {
+                "label": "Password",
+                "name": "password",
+                "type": "password"
+              }
+            ],
+            "has_mfa": true,
+            "health_status": "HEALTH_STATUS_GREEN",
+            "institution_id": "ins_109508",
+            "legacy_institution_code": "ins_109508",
+            "legacy_institution_type": null,
+            "link_health_status": "HEALTH_STATUS_GREEN",
+            "logo": null,
+            "mfa": [
+              "code",
+              "list",
+              "questions",
+              "selections"
+            ],
+            "mfa_code_type": "numeric",
+            "name": "First Platypus Bank",
+            "name_break": null,
+            "portal": null,
+            "products": [
+              "assets",
+              "auth",
+              "balance",
+              "transactions",
+              "credit_details",
+              "income",
+              "identity"
+            ],
+            "url": "https://www.plaid.com/",
+            "url_account_locked": null,
+            "url_account_setup": null,
+            "url_forgotten_password": null
+          },
+          "request_id": "FF0Y18Fj2h1gBOO"
+        }
+    http_version: 
+  recorded_at: Sat, 05 Jan 2019 02:26:53 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Per the request in #202, this PR adds an optional `options` param to the `institutions.get_by_id` method. 

Because `include_display_data: true` returns additional fields in the response, I also updated the `Institution` model. I was unable to find documentation for many of the additionally returned fields so the examples and descriptions in the comments may need some refinement. 

This is my first contribution to Plaid. Happy New Year.