### PR TITLE
Enable Rails/Output cop to catch puts and friends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,5 @@ jobs:
           command: bundle exec rake test
       - run:
           name: Rubocop test
-          command: bundle exec rubocop
+          command: bundle exec rubocop -E
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,12 @@ Metrics/MethodLength:
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false
+
+# We do not actually need Rails checks except Rails/Output, but in order to
+# make it run we have to enable the whole suite.
+Rails:
+  Enabled: true
+
+Rails/Output:
+  Enabled: true
+  Details: "\nActually, do not do console logging at all in the gem."

--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -60,3 +60,5 @@ module Plaid
     date.is_a?(String) ? date : date.to_date.strftime('%Y-%m-%d')
   end
 end
+
+puts 'test'

--- a/lib/plaid.rb
+++ b/lib/plaid.rb
@@ -60,5 +60,3 @@ module Plaid
     date.is_a?(String) ? date : date.to_date.strftime('%Y-%m-%d')
   end
 end
-
-puts 'test'


### PR DESCRIPTION
An ideal solution would require to develop a custom rubocop extension (which I'm considering), but this one would catch `puts`.