### PR TITLE
Add support for Ocrolus as a processor

### DIFF
--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -98,6 +98,34 @@ module Plaid
     subproduct :processor_token, ProcessorToken
   end
 
+  # Public: Class used to call the Ocrolus sub-product.
+  class Ocrolus < BaseProduct
+    # Public: Class used to call the ocrolus.processor_token subproduct
+    class ProcessorToken < BaseProduct
+      # Public: Creates a Ocrolus processor token from an access_token.
+      #
+      # Does a POST /processor/ocrolus/processor_token/create call which can be
+      # used to generate a Ocrolus processor token for a given account ID.
+      #
+      # access_token - access_token to create a public token for.
+      # account_id - ID of the account to create a processor token for.
+      #
+      # Returns a ProcessorTokenResponse object containing a Ocrolus processor
+      # token.
+      def create(access_token, account_id)
+        post_with_auth 'processor/ocrolus/processor_token/create',
+                        ProcessorTokenResponse,
+                        access_token: access_token,
+                        account_id: account_id
+      end
+    end
+
+    ##
+    # :attr_reader:
+    # Public: The Plaid::Ocrolus::ProcessorToken product accessor.
+    subproduct :processor_token, ProcessorToken
+  end
+
   # Public: Class used to call the Processor product.
   class Processor < BaseProduct
     ##
@@ -114,5 +142,10 @@ module Plaid
     # :attr_reader:
     # Public: The Plaid::Apex product accessor.
     subproduct :apex
+
+    ##
+    # :attr_reader:
+    # Public: The Plaid::Ocrolus product accessor.
+    subproduct :ocrolus
   end
 end

--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -114,9 +114,9 @@ module Plaid
       # token.
       def create(access_token, account_id)
         post_with_auth 'processor/ocrolus/processor_token/create',
-                        ProcessorTokenResponse,
-                        access_token: access_token,
-                        account_id: account_id
+                       ProcessorTokenResponse,
+                       access_token: access_token,
+                       account_id: account_id
       end
     end
 

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -26,6 +26,16 @@ class PlaidProcessorTest < PlaidTest
     assert_match(/account_id must be a properly formatted/, error.error_message)
   end
 
+  def test_ocrolus_processor_token_create_invalid_account_id
+    error = assert_raises(Plaid::InvalidRequestError) do
+      client.processor.ocrolus.processor_token.create access_token,
+                                                     BAD_STRING
+    end
+
+    assert_equal 'INVALID_FIELD', error.error_code
+    assert_match(/account_id must be a properly formatted/, error.error_message)
+  end
+
   def test_apex_processor_token_create_invalid_account_id
     error = assert_raises(Plaid::InvalidRequestError) do
       client.processor.apex.processor_token.create access_token,

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -29,7 +29,7 @@ class PlaidProcessorTest < PlaidTest
   def test_ocrolus_processor_token_create_invalid_account_id
     error = assert_raises(Plaid::InvalidRequestError) do
       client.processor.ocrolus.processor_token.create access_token,
-                                                     BAD_STRING
+                                                      BAD_STRING
     end
 
     assert_equal 'INVALID_FIELD', error.error_code

--- a/test/vcr_cassettes/PlaidProcessorTest_test_ocrolus_processor_token_create_invalid_account_id.yml
+++ b/test/vcr_cassettes/PlaidProcessorTest_test_ocrolus_processor_token_create_invalid_account_id.yml
@@ -1,0 +1,264 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/sandbox/public_token/create
+    body:
+      encoding: UTF-8
+      string: '{"institution_id":"ins_109508","initial_products":["auth"],"options":{},"public_key":"PLAID_RUBY_PUBLIC_KEY"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.1.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 27 Aug 2019 19:25:04 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '124'
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "public_token": "public-sandbox-5991f1d6-336a-4aab-9750-571fcae793ab",
+          "request_id": "Dw8PgFGxZ7xUHNd"
+        }
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 19:25:04 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/public_token/exchange
+    body:
+      encoding: UTF-8
+      string: '{"public_token":"public-sandbox-5991f1d6-336a-4aab-9750-571fcae793ab","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.1.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 27 Aug 2019 19:25:05 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '165'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "access-sandbox-35a47e1e-8a3b-450c-a7fe-ce74507298f9",
+          "item_id": "jqGgb9aqR7f99kKoG1w7T8mMv94Jo3i1mqrLQ",
+          "request_id": "q7tSvDE1z2uoiuO"
+        }
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 19:25:05 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/get
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-35a47e1e-8a3b-450c-a7fe-ce74507298f9","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.1.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 27 Aug 2019 19:25:06 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '275'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "item": {
+            "available_products": [
+              "assets",
+              "balance",
+              "credit_details",
+              "identity",
+              "income",
+              "investments",
+              "liabilities",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "jqGgb9aqR7f99kKoG1w7T8mMv94Jo3i1mqrLQ",
+            "webhook": ""
+          },
+          "request_id": "H7agakvjNaijSmi",
+          "status": {
+            "last_webhook": null
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 19:25:06 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/ocrolus/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-35a47e1e-8a3b-450c-a7fe-ce74507298f9","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.1.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 27 Aug 2019 19:25:06 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '194'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "zCdYHSGI3Rl9LWm",
+          "suggested_action": null
+        }
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 19:25:07 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/remove
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-35a47e1e-8a3b-450c-a7fe-ce74507298f9","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.1.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 27 Aug 2019 19:25:07 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '74'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "removed": true,
+          "request_id": "tShdH0DoFIxeG9q"
+        }
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 19:25:07 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Adds a new product class for Ocrolus processor tokens. Code and tests are more or less copypasted from what already exists for other processors.

Once we need to add more of these it'll probably be worth refactoring this a bit more to DRY it out.

~Also, this failed a CI test because the Assets model hadn't been updated to use the new `postal_code` `region` and `country` address fields. Our API changelog mentions this change being made for Identity and Transactions responses; is this a problem? And should I open a separate PR for this change, since it's out of the PR's original scope?~ ~Whoops, just saw https://github.com/plaid/plaid-ruby/pull/236. Should I roll my own address fields change back and wait for 236 to be merged in?~

Now that #236 has been merged, I got rid of the commit where I made the address changes and rebased on latest master. This should be ready for review now.