### PR TITLE
Add support for Modern Treasury as a processor

### DIFF
--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -94,7 +94,7 @@ module Plaid
 
     ##
     # :attr_reader:
-    # Public: The Plaid::ApexProcessorToken product accessor.
+    # Public: The Plaid::Apex::ProcessorToken product accessor.
     subproduct :processor_token, ProcessorToken
   end
 
@@ -105,12 +105,12 @@ module Plaid
       # Public: Creates a Ocrolus processor token from an access_token.
       #
       # Does a POST /processor/ocrolus/processor_token/create call which can be
-      # used to generate a Ocrolus processor token for a given account ID.
+      # used to generate a Modern Treasury processor token for a given account ID.
       #
       # access_token - access_token to create a public token for.
       # account_id - ID of the account to create a processor token for.
       #
-      # Returns a ProcessorTokenResponse object containing a Ocrolus processor
+      # Returns a ProcessorTokenResponse object containing a Modern Treasury processor
       # token.
       def create(access_token, account_id)
         post_with_auth 'processor/ocrolus/processor_token/create',

--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -105,12 +105,12 @@ module Plaid
       # Public: Creates a Ocrolus processor token from an access_token.
       #
       # Does a POST /processor/ocrolus/processor_token/create call which can be
-      # used to generate a Modern Treasury processor token for a given account ID.
+      # used to generate a Ocrolus processor token for a given account ID.
       #
       # access_token - access_token to create a public token for.
       # account_id - ID of the account to create a processor token for.
       #
-      # Returns a ProcessorTokenResponse object containing a Modern Treasury processor
+      # Returns a ProcessorTokenResponse object containing a Ocrolus processor
       # token.
       def create(access_token, account_id)
         post_with_auth 'processor/ocrolus/processor_token/create',
@@ -132,14 +132,15 @@ module Plaid
     class ProcessorToken < BaseProduct
       # Public: Creates a Modern Treasury processor token from an access_token.
       #
-      # Does a POST /processor/modern_treasury/processor_token/create call which can be
-      # used to generate a Modern Treasury processor token for a given account ID.
-      #
+      # Does a POST /processor/modern_treasury/processor_token/create call which
+      # can be used to generate a Modern Treasury processor token for a given
+      # account ID.
+      # 
       # access_token - access_token to create a public token for.
       # account_id - ID of the account to create a processor token for.
       #
-      # Returns a ProcessorTokenResponse object containing a Ocrolus processor
-      # token.
+      # Returns a ProcessorTokenResponse object containing a Modern Treasury
+      # processor token.
       def create(access_token, account_id)
         post_with_auth 'processor/modern_treasury/processor_token/create',
                        ProcessorTokenResponse,

--- a/lib/plaid/products/processor.rb
+++ b/lib/plaid/products/processor.rb
@@ -126,6 +126,34 @@ module Plaid
     subproduct :processor_token, ProcessorToken
   end
 
+  # Public: Class used to call the Modern Treasury sub-product.
+  class ModernTreasury < BaseProduct
+    # Public: Class used to call the modern_treasury.processor_token subproduct
+    class ProcessorToken < BaseProduct
+      # Public: Creates a Modern Treasury processor token from an access_token.
+      #
+      # Does a POST /processor/modern_treasury/processor_token/create call which can be
+      # used to generate a Modern Treasury processor token for a given account ID.
+      #
+      # access_token - access_token to create a public token for.
+      # account_id - ID of the account to create a processor token for.
+      #
+      # Returns a ProcessorTokenResponse object containing a Ocrolus processor
+      # token.
+      def create(access_token, account_id)
+        post_with_auth 'processor/modern_treasury/processor_token/create',
+                       ProcessorTokenResponse,
+                       access_token: access_token,
+                       account_id: account_id
+      end
+    end
+
+    ##
+    # :attr_reader:
+    # Public: The Plaid::ModernTreasury::ProcessorToken product accessor.
+    subproduct :processor_token, ProcessorToken
+  end
+
   # Public: Class used to call the Processor product.
   class Processor < BaseProduct
     ##
@@ -147,5 +175,10 @@ module Plaid
     # :attr_reader:
     # Public: The Plaid::Ocrolus product accessor.
     subproduct :ocrolus
+
+    ##
+    # :attr_reader:
+    # Public: The Plaid::ModernTreasury product accessor.
+    subproduct :modern_treasury
   end
 end

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -45,4 +45,14 @@ class PlaidProcessorTest < PlaidTest
     assert_equal 'INVALID_FIELD', error.error_code
     assert_match(/account_id must be a properly formatted/, error.error_message)
   end
+
+  def test_modern_treasury_processor_token_create_invalid_account_id
+    error = assert_raises(Plaid::InvalidRequestError) do
+      client.processor.modern_treasury.processor_token.create access_token,
+                                                              BAD_STRING
+    end
+
+    assert_equal 'INVALID_FIELD', error.error_code
+    assert_match(/account_id must be a properly formatted/, error.error_message)
+  end
 end

--- a/test/vcr_cassettes/PlaidProcessorTest_test_modern_treasury_processor_token_create_invalid_account_id.yml
+++ b/test/vcr_cassettes/PlaidProcessorTest_test_modern_treasury_processor_token_create_invalid_account_id.yml
@@ -1,0 +1,263 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/sandbox/public_token/create
+    body:
+      encoding: UTF-8
+      string: '{"institution_id":"ins_109508","initial_products":["auth"],"options":{},"public_key":"PLAID_RUBY_PUBLIC_KEY"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.3.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 05 Dec 2019 08:12:22 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '124'
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "public_token": "public-sandbox-829bb45f-a55e-417c-93fe-02ba415cbaed",
+          "request_id": "o4ZlH7AfqKIOpnt"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 08:12:23 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/public_token/exchange
+    body:
+      encoding: UTF-8
+      string: '{"public_token":"public-sandbox-829bb45f-a55e-417c-93fe-02ba415cbaed","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.3.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 05 Dec 2019 08:12:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '169'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "access-sandbox-c693b558-7ad6-4b52-bb9c-33274a75b8a7",
+          "item_id": "y1gm5N6NjAiKyzEDwgZLuJdjR1KMldcyd8bjW",
+          "request_id": "9u9FVZ3KVRXDHlG"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 08:12:23 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/get
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-c693b558-7ad6-4b52-bb9c-33274a75b8a7","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.3.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 05 Dec 2019 08:12:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '272'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "item": {
+            "available_products": [
+              "assets",
+              "balance",
+              "identity",
+              "income",
+              "investments",
+              "liabilities",
+              "transactions"
+            ],
+            "billed_products": [
+              "auth"
+            ],
+            "error": null,
+            "institution_id": "ins_109508",
+            "item_id": "y1gm5N6NjAiKyzEDwgZLuJdjR1KMldcyd8bjW",
+            "webhook": ""
+          },
+          "request_id": "HvnAEj5wMhVgzT4",
+          "status": {
+            "last_webhook": null
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 08:12:23 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/processor/modern_treasury/processor_token/create
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-c693b558-7ad6-4b52-bb9c-33274a75b8a7","account_id":"ABCDEFG1234567","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.3.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 05 Dec 2019 08:12:24 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '194'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "display_message": null,
+          "error_code": "INVALID_FIELD",
+          "error_message": "account_id must be a properly formatted, non-empty string",
+          "error_type": "INVALID_REQUEST",
+          "request_id": "9GxUsYO7Npp3zgP",
+          "suggested_action": null
+        }
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 08:12:24 GMT
+- request:
+    method: post
+    uri: https://sandbox.plaid.com/item/remove
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access-sandbox-c693b558-7ad6-4b52-bb9c-33274a75b8a7","client_id":"PLAID_RUBY_CLIENT_ID","secret":"PLAID_RUBY_SECRET"}'
+    headers:
+      User-Agent:
+      - Plaid Ruby v8.3.0
+      Content-Type:
+      - application/json
+      Plaid-Version:
+      - '2019-05-29'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 05 Dec 2019 08:12:24 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '74'
+      connection:
+      - close
+      plaid-version:
+      - '2019-05-29'
+      vary:
+      - Accept-Encoding
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-frame-options:
+      - DENY
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "removed": true,
+          "request_id": "yI4r1MXUTpHajFH"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Dec 2019 08:12:24 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Adds a new product class for [Modern Treasury](https://plaid.com/docs/modern-treasury/) processor tokens. Code and tests are the same as the extant processors. 