### PR TITLE
Fix PlaidInstitutionsTest, PlaidInvestmentsTest, and PlaidTransactionsTest

### DIFF
--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -986,6 +986,12 @@ module Plaid
       # :attr_reader:
       # Public: The String unofficial currency code for the amount
       property :unofficial_currency_code
+
+      ##
+      # :attr_reader:
+      # Public: The String channel used to make a payment, e.g.
+      # "online", "in store", or "other".
+      property :payment_channel
     end
 
     # Public: A representation of an InvestmentTransaction in an investment

--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -1012,6 +1012,12 @@ module Plaid
       # Public: The String channel used to make a payment, e.g.
       # "online", "in store", or "other".
       property :payment_channel
+
+      ##
+      # :attr_reader:
+      # Public: The String date that the transaction was authorized,
+      # e.g. "2017-01-01".
+      property :authorized_date
     end
 
     # Public: A representation of an InvestmentTransaction in an investment

--- a/lib/plaid/models.rb
+++ b/lib/plaid/models.rb
@@ -159,6 +159,21 @@ module Plaid
       property :last_successful_update
     end
 
+    # Public: A representation of Item investments update status
+    class ItemStatusInvestments < BaseModel
+      ##
+      # :attr_reader:
+      # Public: the String last failed update date (or nil).
+      # (e.g. "2019-04-22T00:00:00Z").
+      property :last_failed_update
+
+      ##
+      # :attr_reader:
+      # Public: the String last successful update date (or nil).
+      # (e.g. "2019-04-22T00:00:00Z").
+      property :last_successful_update
+    end
+
     # Public: A representation of Item status
     class ItemStatus < BaseModel
       ##
@@ -170,6 +185,11 @@ module Plaid
       # :attr_reader:
       # Public: The ItemStatusTransactions for this ItemStatus.
       property :transactions, coerce: ItemStatusTransactions
+
+      ##
+      # :attr_reader:
+      # Public: The ItemStatusInvestments for this ItemStatus.
+      property :investments, coerce: ItemStatusInvestments
     end
 
     # Public: A representation of account balances.

--- a/test/test_institutions.rb
+++ b/test/test_institutions.rb
@@ -48,14 +48,6 @@ class PlaidInstitutionsTest < PlaidTest
     assert_nil(response.institution.status)
   end
 
-  def test_get_by_id_include_status
-    response = client.institutions.get_by_id(SANDBOX_INSTITUTION,
-                                             options:
-                                             { include_status: true })
-    assert_equal(SANDBOX_INSTITUTION, response.institution.institution_id)
-    refute_empty(response.institution.status)
-  end
-
   def test_search
     response = client.institutions.search(SANDBOX_INSTITUTION_NAME)
     refute_empty(response.institutions)


### PR DESCRIPTION
If there is not enough traffic to accurately calculate institution status, as is the case in the sandbox environment, the API returns null rather than potentially inaccurate data, so the status test no longer works.