### PR TITLE
set verification status

### DIFF
--- a/lib/plaid/products/sandbox.rb
+++ b/lib/plaid/products/sandbox.rb
@@ -57,7 +57,7 @@ module Plaid
     # Returns a Models::BaseResponse object.
     def set_verification_status(access_token, account_id, verification_status)
       post_with_auth '/sandbox/item/set_verification_status',
-                     FireWebhookResponse,
+                     Models::BaseResponse,
                      access_token: access_token,
                      account_id: account_id,
                      verification_status: verification_status

--- a/lib/plaid/products/sandbox.rb
+++ b/lib/plaid/products/sandbox.rb
@@ -44,6 +44,24 @@ module Plaid
       # Public: The Boolean webhook fired success flag.
       property :webhook_fired
     end
+
+    # Public: Sets the verification status for an item
+    # created via automated microdeposits
+    #
+    # Does a POST /sandbox/item/set_verification_status call.
+    #
+    # access_token - access_token of the item
+    # account_id - id of the account to verify
+    # verification_status - status to set
+    #
+    # Returns a Models::BaseResponse object.
+    def set_verification_status(access_token, account_id, verification_status)
+      post_with_auth '/sandbox/item/set_verification_status',
+                     FireWebhookResponse,
+                     access_token: access_token,
+                     account_id: account_id,
+                     verification_status: verification_status
+    end
   end
 
   # Public: Class used to call the SandboxPublicToken sub-product


### PR DESCRIPTION
method to set verification status on an item from the AMD flow

tested manually with
```
require_relative 'Plaid'

client = Plaid::Client.new(env: :sandbox,
                           client_id: '...',
                           secret: '...',
                           public_key: '...')

resp = client.sandbox.sandbox_item.set_verification_status('...', 'GMxydz6kM4tDdrPJBwPXiPzQ7Pwabaf1oq84a', 'verification_expired')
print(resp)