### PR TITLE
Fix error type mapping for RateLimitExceededError

### DIFF
--- a/lib/plaid/errors.rb
+++ b/lib/plaid/errors.rb
@@ -63,7 +63,7 @@ TEXT
     ERROR_TYPE_MAP = {
       'INVALID_REQUEST' => Plaid::InvalidRequestError,
       'INVALID_INPUT' => Plaid::InvalidInputError,
-      'RATE_LIMIT_EXCEEDED_ERROR' => Plaid::RateLimitExceededError,
+      'RATE_LIMIT_EXCEEDED' => Plaid::RateLimitExceededError,
       'API_ERROR' => Plaid::APIError,
       'ITEM_ERROR' => Plaid::ItemError
     }.freeze


### PR DESCRIPTION
This PR fixes the error type mapping for the `Plaid::RateLimitExceededError`. As seen in the [plaid docs](plaid.com/docs/#rate-limit-exceeded-errors), the `error_type` in the response is actually `"RATE_LIMIT_EXCEEDED"` not `"RATE_LIMIT_EXCEEDED_ERROR"`