### PR TITLE
Add missing versions to API version support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each major version of `plaid-ruby` targets a specific version of the Plaid API:
 
 | API version | plaid-ruby release |
 | ----------- | ------------------ |
-| [`2019-05-29`][api-version-2019-05-29] (**latest**) | `9.x.x`, `8.x.x`, `7.x.x` |
+| [`2019-05-29`][api-version-2019-05-29] (**latest**) | `11.x.x`, `10.x.x`, `9.x.x`, `8.x.x`, `7.x.x` |
 | [`2018-05-22`][api-version-2018-05-22] | `6.x.x` |
 | `2017-03-08` | `5.x.x` |
 


### PR DESCRIPTION
This almost tripped me up. Not entirely sure if this is correct, but looks like it from the changelog. I got confused into thinking version 11 wasn't a final release yet.