### PR TITLE
add back legacy token endpoints

### DIFF
--- a/lib/plaid/products/item.rb
+++ b/lib/plaid/products/item.rb
@@ -25,8 +25,61 @@ module Plaid
     end
   end
 
+  # Public: Class used to call the AddToken sub-product.	
+  class AddToken < BaseProduct	
+    def create(user)	
+      puts 'Warning: this method will be deprecated in a future version. To replace the item_add_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
+
+      post_with_auth 'item/add_token/create',	
+                     CreateResponse,	
+                     user: user	
+    end	
+
+    # Public: Response for /item/add_token/create.	
+    class CreateResponse < Models::BaseResponse	
+      ##	
+      # :attr_reader:	
+      # Public: The String token.	
+      property :add_token	
+
+      ##	
+      # :attr_reader:	
+      # Public: The String token expiration time.	
+      property :expiration	
+    end	
+  end
+
   # Public: Class used to call the PublicToken sub-product
   class PublicToken < BaseProduct
+    # Public: Creates a public token from an access_token.	
+    #	
+    # Does a POST /item/public_token/create call which can be used to	
+    # initialize Link in update mode.	
+    #	
+    # access_token - access_token to create a public token for	
+    #	
+    # Returns a CreateResponse object with a public token and expiration info.	
+    def create(access_token)	
+      puts 'Warning: this method will be deprecated in a future version. To replace the public_token for initializing Link, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
+
+      post_with_auth 'item/public_token/create',	
+                     CreateResponse,	
+                     access_token: access_token	
+    end	
+
+    # Public: Response for /item/public_token/create.	
+    class CreateResponse < Models::BaseResponse	
+      ##	
+      # :attr_reader:	
+      # Public: The String token.	
+      property :public_token	
+
+      ##	
+      # :attr_reader:	
+      # Public: The String token expiration time.	
+      property :expiration	
+    end
+
     # Public: Exchange a public token for an access_token
     #
     # Does a POST /item/public_token/exchange call helps you exchange a public
@@ -96,6 +149,11 @@ module Plaid
     # :attr_reader:
     # Public: The Plaid::PublicToken product accessor.
     subproduct :public_token
+
+    ##	
+    # :attr_reader:	
+    # Public: The Plaid::AddToken product accessor.	
+    subproduct :add_token
 
     ##
     # :attr_reader:

--- a/lib/plaid/products/item.rb
+++ b/lib/plaid/products/item.rb
@@ -27,33 +27,33 @@ module Plaid
 
   # Public: Class used to call the PublicToken sub-product
   class PublicToken < BaseProduct
-    # Public: Creates a public token from an access_token.	
-    #	
-    # Does a POST /item/public_token/create call which can be used to	
-    # initialize Link in update mode.	
-    #	
-    # access_token - access_token to create a public token for	
-    #	
-    # Returns a CreateResponse object with a public token and expiration info.	
-    def create(access_token)	
+    # Public: Creates a public token from an access_token.
+    #
+    # Does a POST /item/public_token/create call which can be used to
+    # initialize Link in update mode.
+    #
+    # access_token - access_token to create a public token for
+    #
+    # Returns a CreateResponse object with a public token and expiration info.
+    def create(access_token)
       puts 'Warning: this method will be deprecated in a future version. To replace the public_token for initializing Link, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
 
-      post_with_auth 'item/public_token/create',	
-                     CreateResponse,	
-                     access_token: access_token	
-    end	
+      post_with_auth 'item/public_token/create',
+                     CreateResponse,
+                     access_token: access_token
+    end
 
-    # Public: Response for /item/public_token/create.	
-    class CreateResponse < Models::BaseResponse	
+    # Public: Response for /item/public_token/create.
+    class CreateResponse < Models::BaseResponse
       ##	
-      # :attr_reader:	
-      # Public: The String token.	
-      property :public_token	
+      # :attr_reader:
+      # Public: The String token.
+      property :public_token
 
-      ##	
-      # :attr_reader:	
-      # Public: The String token expiration time.	
-      property :expiration	
+      ##
+      # :attr_reader:
+      # Public: The String token expiration time.
+      property :expiration
     end
 
     # Public: Exchange a public token for an access_token

--- a/lib/plaid/products/item.rb
+++ b/lib/plaid/products/item.rb
@@ -25,30 +25,6 @@ module Plaid
     end
   end
 
-  # Public: Class used to call the AddToken sub-product.	
-  class AddToken < BaseProduct	
-    def create(user)	
-      puts 'Warning: this method will be deprecated in a future version. To replace the item_add_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
-
-      post_with_auth 'item/add_token/create',	
-                     CreateResponse,	
-                     user: user	
-    end	
-
-    # Public: Response for /item/add_token/create.	
-    class CreateResponse < Models::BaseResponse	
-      ##	
-      # :attr_reader:	
-      # Public: The String token.	
-      property :add_token	
-
-      ##	
-      # :attr_reader:	
-      # Public: The String token expiration time.	
-      property :expiration	
-    end	
-  end
-
   # Public: Class used to call the PublicToken sub-product
   class PublicToken < BaseProduct
     # Public: Creates a public token from an access_token.	
@@ -149,11 +125,6 @@ module Plaid
     # :attr_reader:
     # Public: The Plaid::PublicToken product accessor.
     subproduct :public_token
-
-    ##	
-    # :attr_reader:	
-    # Public: The Plaid::AddToken product accessor.	
-    subproduct :add_token
 
     ##
     # :attr_reader:

--- a/lib/plaid/products/item.rb
+++ b/lib/plaid/products/item.rb
@@ -36,7 +36,9 @@ module Plaid
     #
     # Returns a CreateResponse object with a public token and expiration info.
     def create(access_token)
-      puts 'Warning: this method will be deprecated in a future version. To replace the public_token for initializing Link, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
+      puts 'Warning: this method will be deprecated in a future version. '\
+           'To replace the public_token for initializing Link, look into '\
+           'the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
 
       post_with_auth 'item/public_token/create',
                      CreateResponse,
@@ -45,7 +47,7 @@ module Plaid
 
     # Public: Response for /item/public_token/create.
     class CreateResponse < Models::BaseResponse
-      ##	
+      ##
       # :attr_reader:
       # Public: The String token.
       property :public_token

--- a/lib/plaid/products/payment_initiation.rb
+++ b/lib/plaid/products/payment_initiation.rb
@@ -53,6 +53,19 @@ module Plaid
                      amount: amount
     end
 
+    # Public: Create a payment token.	
+    #	
+    # payment_id - Payment ID that the token will be created for.	
+    #	
+    # Returns a PaymentTokenCreateResponse object.	
+    def create_payment_token(payment_id)	
+      puts 'Warning: this method will be deprecated in a future version. To replace the payment_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
+
+      post_with_auth 'payment_initiation/payment/token/create',	
+                     PaymentTokenCreateResponse,	
+                     payment_id: payment_id	
+    end
+
     # Public: Retrieve a payment.
     #
     # payment_id - The payment ID from the `create_payment` response.
@@ -134,6 +147,20 @@ module Plaid
     # Public: The payment status.
     property :status
   end
+
+  # Public: The response wrapper for /payment_initiation/payment/token/create.	
+  class PaymentTokenCreateResponse < Models::BaseResponse	
+    ##	
+    # :attr_reader:	
+    # Public: The payment token.	
+    property :payment_token	
+
+    ##	
+    # :attr_reader:	
+    # Public: The payment token's expiration time.	
+    property :payment_token_expiration_time	
+  end	
+
 
   # Public: The response wrapper for /payment_initiation/payment/get.
   class PaymentGetResponse < Models::BaseResponse

--- a/lib/plaid/products/payment_initiation.rb
+++ b/lib/plaid/products/payment_initiation.rb
@@ -59,7 +59,9 @@ module Plaid
     #
     # Returns a PaymentTokenCreateResponse object.
     def create_payment_token(payment_id)
-      puts 'Warning: this method will be deprecated in a future version. To replace the payment_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
+      puts 'Warning: this method will be deprecated in a future version. '\
+           'To replace the payment_token, look into the link_token at '\
+           'https://plaid.com/docs/api/tokens/#linktokencreate.'
 
       post_with_auth 'payment_initiation/payment/token/create',
                      PaymentTokenCreateResponse,
@@ -148,19 +150,18 @@ module Plaid
     property :status
   end
 
-  # Public: The response wrapper for /payment_initiation/payment/token/create.	
-  class PaymentTokenCreateResponse < Models::BaseResponse	
-    ##	
-    # :attr_reader:	
-    # Public: The payment token.	
-    property :payment_token	
+  # Public: The response wrapper for /payment_initiation/payment/token/create.
+  class PaymentTokenCreateResponse < Models::BaseResponse
+    ##
+    # :attr_reader:
+    # Public: The payment token.
+    property :payment_token
 
-    ##	
-    # :attr_reader:	
-    # Public: The payment token's expiration time.	
-    property :payment_token_expiration_time	
-  end	
-
+    ##
+    # :attr_reader:
+    # Public: The payment token's expiration time.
+    property :payment_token_expiration_time
+  end
 
   # Public: The response wrapper for /payment_initiation/payment/get.
   class PaymentGetResponse < Models::BaseResponse

--- a/lib/plaid/products/payment_initiation.rb
+++ b/lib/plaid/products/payment_initiation.rb
@@ -53,17 +53,17 @@ module Plaid
                      amount: amount
     end
 
-    # Public: Create a payment token.	
-    #	
-    # payment_id - Payment ID that the token will be created for.	
-    #	
-    # Returns a PaymentTokenCreateResponse object.	
-    def create_payment_token(payment_id)	
+    # Public: Create a payment token.
+    #
+    # payment_id - Payment ID that the token will be created for.
+    #
+    # Returns a PaymentTokenCreateResponse object.
+    def create_payment_token(payment_id)
       puts 'Warning: this method will be deprecated in a future version. To replace the payment_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.'
 
-      post_with_auth 'payment_initiation/payment/token/create',	
-                     PaymentTokenCreateResponse,	
-                     payment_id: payment_id	
+      post_with_auth 'payment_initiation/payment/token/create',
+                     PaymentTokenCreateResponse,
+                     payment_id: payment_id
     end
 
     # Public: Retrieve a payment.

--- a/test/test_item.rb
+++ b/test/test_item.rb
@@ -115,6 +115,33 @@ class PlaidItemTest < PlaidTest # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def test_public_token_invalid_access_token	
+    assert_raises(Plaid::InvalidInputError) do	
+      client.item.public_token.create(BAD_STRING)	
+    end	
+  end	
+
+  def test_add_token_create	
+    add_token_response = client.item.add_token.create(	
+      client_user_id: '123-fake-user-id'	
+    )	
+    refute_empty(add_token_response.add_token)	
+    refute_empty(add_token_response.expiration)	
+  end	
+
+  def test_add_token_create_with_user_fields	
+    add_token_response = client.item.add_token.create(	
+      client_user_id: '123-fake-user-id',	
+      legal_name: 'John Doe',	
+      phone_number: '+1 415 555 0123',	
+      phone_number_verified_time: '2020-01-01T00:00:00Z',	
+      email_address: 'example@plaid.com',	
+      email_address_verified_time: '2020-01-01T00:00:00Z'	
+    )	
+    refute_empty(add_token_response.add_token)	
+    refute_empty(add_token_response.expiration)	
+  end
+
   def test_public_token_sandbox
     public_token_response = client.sandbox.sandbox_public_token.create(
       institution_id: SANDBOX_INSTITUTION,

--- a/test/test_item.rb
+++ b/test/test_item.rb
@@ -121,27 +121,6 @@ class PlaidItemTest < PlaidTest # rubocop:disable Metrics/ClassLength
     end	
   end	
 
-  def test_add_token_create	
-    add_token_response = client.item.add_token.create(	
-      client_user_id: '123-fake-user-id'	
-    )	
-    refute_empty(add_token_response.add_token)	
-    refute_empty(add_token_response.expiration)	
-  end	
-
-  def test_add_token_create_with_user_fields	
-    add_token_response = client.item.add_token.create(	
-      client_user_id: '123-fake-user-id',	
-      legal_name: 'John Doe',	
-      phone_number: '+1 415 555 0123',	
-      phone_number_verified_time: '2020-01-01T00:00:00Z',	
-      email_address: 'example@plaid.com',	
-      email_address_verified_time: '2020-01-01T00:00:00Z'	
-    )	
-    refute_empty(add_token_response.add_token)	
-    refute_empty(add_token_response.expiration)	
-  end
-
   def test_public_token_sandbox
     public_token_response = client.sandbox.sandbox_public_token.create(
       institution_id: SANDBOX_INSTITUTION,

--- a/test/test_item.rb
+++ b/test/test_item.rb
@@ -115,11 +115,11 @@ class PlaidItemTest < PlaidTest # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def test_public_token_invalid_access_token	
-    assert_raises(Plaid::InvalidInputError) do	
-      client.item.public_token.create(BAD_STRING)	
-    end	
-  end	
+  def test_public_token_invalid_access_token
+    assert_raises(Plaid::InvalidInputError) do
+      client.item.public_token.create(BAD_STRING)
+    end
+  end
 
   def test_public_token_sandbox
     public_token_response = client.sandbox.sandbox_public_token.create(

--- a/test/test_payment_initiation.rb
+++ b/test/test_payment_initiation.rb
@@ -61,6 +61,11 @@ class PlaidPaymentInitiationTest < PlaidTest
     refute_empty(create_link_token_response.link_token)
     refute_empty(create_link_token_response.expiration)
 
+    # create legacy payment_token (deprecated)
+    create_payment_token_response = client.payment_initiation.create_payment_token(payment_id)
+    refute_empty(create_payment_token_response.payment_token)
+    refute_empty(create_payment_token_response.payment_token_expiration_time)
+
     # get payment
     get_payment_response = client.payment_initiation.get_payment(payment_id)
     refute_empty(get_payment_response.payment_id)

--- a/test/test_payment_initiation.rb
+++ b/test/test_payment_initiation.rb
@@ -62,7 +62,8 @@ class PlaidPaymentInitiationTest < PlaidTest
     refute_empty(create_link_token_response.expiration)
 
     # create legacy payment_token (deprecated)
-    create_payment_token_response = client.payment_initiation.create_payment_token(payment_id)
+    create_payment_token_response =
+      client.payment_initiation.create_payment_token(payment_id)
     refute_empty(create_payment_token_response.payment_token)
     refute_empty(create_payment_token_response.payment_token_expiration_time)
 


### PR DESCRIPTION
Add back support for the legacy token create endpoints but mark them as deprecated since we advice new client library users from using them. They will be supported in this version but will eventually be eventually be removed for real in some future version.

/item/public_token/create
/item/add_token/create
/payment_initiation/payment/token/create