### PR TITLE
Fix issue with non-raised server errors (50X)

### DIFF
--- a/lib/plaid/middleware.rb
+++ b/lib/plaid/middleware.rb
@@ -14,10 +14,11 @@ module Plaid
 
     # Internal: Default read timeout for HTTP calls in seconds.
     NETWORK_TIMEOUT = 600
+    # Internal: Status codes recognized as client or server errors.
+    ERROR_STATUSES = 400...600
 
     def on_complete(env)
-      return unless Faraday::Response::RaiseError::ClientErrorStatuses
-                    .include?(env[:status])
+      return unless ERROR_STATUSES.include?(env[:status])
 
       error_class = Plaid::Error.error_from_type(env.body['error_type'])
 


### PR DESCRIPTION
In its 1.0 release, Faraday split `Response::RaiseError::ClientErrorStatuses` apart into a second `ServerErrorStatuses` constant.

This gem relied on `ClientErrorStatuses` to return `400...600`, but now it returns `400...500` instead. This means that if Plaid's API returns a 50X code, and the consuming application is running Faraday 1.0+, no Ruby error will raise and code execution will continue as if a successful response had been returned.

This change decouples Plaid's middleware from Faraday's internal constants, such that both pre-1.0 and post-1.0 versions of Faraday should be supported.