### PR TITLE
Added automatically_verified to allowed verification statuses

### DIFF
--- a/lib/plaid/models/account_base.rb
+++ b/lib/plaid/models/account_base.rb
@@ -179,7 +179,7 @@ module Plaid
       return false if @balances.nil?
       return false if @name.nil?
       return false if @type.nil?
-      verification_status_validator = EnumAttributeValidator.new('String', ["pending_automatic_verification", "pending_manual_verification", "manually_verified", "verification_expired", "verification_failed"])
+      verification_status_validator = EnumAttributeValidator.new('String', ["automatically_verified", "pending_automatic_verification", "pending_manual_verification", "manually_verified", "verification_expired", "verification_failed"])
       return false unless verification_status_validator.valid?(@verification_status)
       true
     end
@@ -187,7 +187,7 @@ module Plaid
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] verification_status Object to be assigned
     def verification_status=(verification_status)
-      validator = EnumAttributeValidator.new('String', ["pending_automatic_verification", "pending_manual_verification", "manually_verified", "verification_expired", "verification_failed"])
+      validator = EnumAttributeValidator.new('String', ["automatically_verified", "pending_automatic_verification", "pending_manual_verification", "manually_verified", "verification_expired", "verification_failed"])
       unless validator.valid?(verification_status)
         fail ArgumentError, "invalid value for \"verification_status\", must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
Creating a stripe bank account token for Automated Microdeposit accounts is currently failing because `automatically_verified` is not currently contained in the list of allowed verification statuses.

ArgumentError: invalid value for "verification_status", must be one of ["pending_automatic_verification", "pending_manual_verification", "manually_verified", "verification_expired", "verification_failed"]. from plaid-14.0.0/lib/plaid/models/account_base.rb:192:in `verification_status='

Following docs on [/sandbox/item/set_verification_status](https://plaid.com/docs/api/sandbox/#sandboxitemset_verification_status), the possible values from sandbox are "automatically_verified" and "verification_expired", but "automatically_verified" doesn't currently work. Haven't had a chance to see how this works outside of sandbox environment yet, but I imagine the problem would be the same.. 