### PR TITLE
Manually change IncomeBreakdown to Array<IncomeBreakdown>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.0.0.beta.5-plural-income-breakdown
+Manually change IncomeBreakdown to Array<IncomeBreakdown> in the Paystub class.
+*This change was not auto-generated and will only be available on this release and Gem versions >=14.1.0*
+
 # 14.0.0.beta.5
 Generated from OAS version 2020-09-14_1.16.4. See full changelog [here](https://github.com/plaid/plaid-openapi/blob/master/CHANGELOG.md).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    plaid (14.0.0.beta.5)
+    plaid (14.0.0.beta.5.pre.plural.pre.income.pre.breakdown)
       faraday (~> 1.0, >= 1.0.1)
 
 GEM
@@ -10,15 +10,25 @@ GEM
     ast (2.4.1)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
-    faraday (1.4.1)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     minitest (5.14.2)
     minitest-around (0.5.0)
       minitest (~> 5.0)
@@ -55,7 +65,7 @@ GEM
     rubocop-ast (0.4.2)
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -72,4 +82,4 @@ DEPENDENCIES
   rubocop (~> 0.91.0)
 
 BUNDLED WITH
-   2.2.9
+   2.2.22

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 # Ruby embeds the version in the generator where as others don't so it's not possible to cat for it.
-RUBY_PACKAGE_VERSION=14.0.0.beta.5
+RUBY_PACKAGE_VERSION=14.0.0.beta.5-plural-income-breakdown

--- a/lib/plaid/models/paystub.rb
+++ b/lib/plaid/models/paystub.rb
@@ -58,7 +58,7 @@ module Plaid
         :'employer' => :'Employer',
         :'employee' => :'Employee',
         :'pay_period_details' => :'PayPeriodDetails',
-        :'income_breakdown' => :'IncomeBreakdown',
+        :'income_breakdown' => :'Array<IncomeBreakdown>',
         :'ytd_earnings' => :'PaystubYTDDetails'
       }
     end

--- a/lib/plaid/version.rb
+++ b/lib/plaid/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.1.0
 =end
 
 module Plaid
-  VERSION = '14.0.0.beta.5'
+  VERSION = '14.0.0.beta.5-plural-income-breakdown'
 end


### PR DESCRIPTION
Manually change IncomeBreakdown to Array<IncomeBreakdown> in the Paystub class.
*This change was not auto-generated and will only be available on this release and Gem versions >=14.1.0*

This is to fix an issue in `14.0.0.beta.5` and will be released as `14.0.0.beta.5-plural-income-breakdown`