### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,8 @@ Read more about response codes and their meaning in the
 
 ## Response Objects
 
-Any API call returns a response object which is accessible by dot notation
-(`response.foo.bar`) or Symbols and Strings as keys: `response[:foo][:bar]`
-and `response['foo']['bar']`. Expected keys for all types of responses are defined,
+Any API call returns a response object which is accessible only by dot notation
+(`response.foo.bar`) and not by bracket notation. Expected keys for all types of responses are defined,
 and any attempt to access an unknown key will cause `NoMethodError` exception.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ transactions = transaction_response.transactions
 
 # the transactions in the response are paginated, so make multiple calls while
 # increasing the offset to retrieve all transactions
-while transactions.length < transaction_response['total_transactions']
+while transactions.length < transaction_response.total_transactions
   options_payload = {}
   options_payload[:offset] = transactions.length
 


### PR DESCRIPTION
changes response object language to only be accessible by dot notation and not bracket notation