### PR TITLE
Fix `NoMethodError` in `LinkTokenCreateRequest#list_invalid_properties`

### DIFF
--- a/lib/plaid/models/link_token_create_request.rb
+++ b/lib/plaid/models/link_token_create_request.rb
@@ -265,7 +265,7 @@ module Plaid
       end
 
 
-      if @country_codes.length < 1
+      if @country_codes && @country_codes.length < 1
         invalid_properties.push('invalid value for "country_codes", number of items must be greater than or equal to 1.')
       end
 


### PR DESCRIPTION
When supplied `country_codes` of `nil`, the `list_invalid_properties` will raise `NoMethodError` because `#length` is being called on `nil`.

```
request = ::Plaid::LinkTokenCreateRequest.new(products: ['transactions'])

request.valid? # => false

request.list_invalid_properties # => NoMethodError: undefined method `length' for nil:NilClass
```