### PR TITLE
Gracefully handle bodies which are invalid from the JSON perspective

### DIFF
--- a/lib/plaid/api_client.rb
+++ b/lib/plaid/api_client.rb
@@ -77,10 +77,13 @@ module Plaid
             fail ApiError.new(:code => 0,
                               :message => response.return_message)
           else
+            raw_body = response.body
+            # Gracefully handle malformed body which is possible during API outage/maintanance
+            parsed_body = JSON.parse(raw_body) rescure nil
             fail ApiError.new(:code => response.status,
                               :response_headers => response.headers,
-                              :response_body => response.body,
-                              :data => JSON.parse(response.body)),
+                              :response_body => raw_body,
+                              :data => parsed_body),
                  response.reason_phrase
           end
         end

--- a/lib/plaid/api_client.rb
+++ b/lib/plaid/api_client.rb
@@ -79,7 +79,12 @@ module Plaid
           else
             raw_body = response.body
             # Gracefully handle malformed body which is possible during API outage/maintanance
-            parsed_body = JSON.parse(raw_body) rescue nil
+            parsed_body = begin
+                JSON.parse(raw_body)
+              rescue JSON::ParserError
+                nil
+              end
+
             fail ApiError.new(:code => response.status,
                               :response_headers => response.headers,
                               :response_body => raw_body,

--- a/lib/plaid/api_client.rb
+++ b/lib/plaid/api_client.rb
@@ -79,7 +79,7 @@ module Plaid
           else
             raw_body = response.body
             # Gracefully handle malformed body which is possible during API outage/maintanance
-            parsed_body = JSON.parse(raw_body) rescure nil
+            parsed_body = JSON.parse(raw_body) rescue nil
             fail ApiError.new(:code => response.status,
                               :response_headers => response.headers,
                               :response_body => raw_body,

--- a/templates/ruby/api_client_faraday_partial.mustache
+++ b/templates/ruby/api_client_faraday_partial.mustache
@@ -23,10 +23,18 @@
             fail ApiError.new(:code => 0,
                               :message => response.return_message)
           else
+            raw_body = response.body
+            # Gracefully handle malformed body which is possible during API outage/maintanance
+            parsed_body = begin
+               JSON.parse(raw_body)
+             rescue JSON::ParserError
+               nil
+             end
+
             fail ApiError.new(:code => response.status,
                               :response_headers => response.headers,
-                              :response_body => response.body,
-                              :data => JSON.parse(response.body)),
+                              :response_body => raw_body,
+                              :data => parsed_body),
                  response.reason_phrase
           end
         end


### PR DESCRIPTION
In case a body contains any malformed JSON which can be even a blank string the code will raise a generic and not wrap the ApiError. Which then leads to inconsistent handling of the error on the gem users' side.

In example in case of the blank string in the body the gem will raise: `JSON::ParserError: 859: unexpected token at ''`