### PR TITLE
Adds specific errors for connection timeout and failure

### DIFF
--- a/lib/plaid/api_client.rb
+++ b/lib/plaid/api_client.rb
@@ -20,6 +20,7 @@ require 'logger'
 require 'tempfile'
 require 'faraday'
 require 'faraday/multipart'
+require_relative 'api_error'
 
 module Plaid
   class ApiClient

--- a/lib/plaid/api_client.rb
+++ b/lib/plaid/api_client.rb
@@ -23,6 +23,9 @@ require 'faraday/multipart'
 
 module Plaid
   class ApiClient
+    class ApiTimeoutError < ApiError; end
+    class ApiConnectionFailedError < ApiError; end
+
     # The Configuration object holding settings to be used in the API client.
     attr_accessor :config
 
@@ -99,9 +102,9 @@ module Plaid
           end
         end
       rescue Faraday::TimeoutError
-        fail ApiError.new('Connection timed out')
+        fail ApiTimeoutError.new('Connection timed out')
       rescue Faraday::ConnectionFailed
-        fail ApiError.new('Connection failed')
+        fail ApiConnectionFailedError.new('Connection failed')
       end
 
       if opts[:return_type]

--- a/templates/ruby/api_client.mustache
+++ b/templates/ruby/api_client.mustache
@@ -20,6 +20,11 @@ require 'faraday/multipart'
 
 module {{moduleName}}
   class ApiClient
+{{#isFaraday}}
+    class ApiTimeoutError < ApiError; end
+    class ApiConnectionFailedError < ApiError; end
+
+{{/isFaraday}}
     # The Configuration object holding settings to be used in the API client.
     attr_accessor :config
 

--- a/templates/ruby/api_client_faraday_partial.mustache
+++ b/templates/ruby/api_client_faraday_partial.mustache
@@ -41,9 +41,9 @@
           end
         end
       rescue Faraday::TimeoutError
-        fail ApiError.new('Connection timed out')
+        fail ApiTimeoutError.new('Connection timed out')
       rescue Faraday::ConnectionFailed
-        fail ApiError.new('Connection failed')
+        fail ApiConnectionFailedError.new('Connection failed')
       end
 
       if opts[:return_type]

--- a/test/test_api_client.rb
+++ b/test/test_api_client.rb
@@ -1,11 +1,10 @@
 require 'faraday'
 require 'faraday/multipart'
 
-
 require_relative "test_helper"
 
 # Internal: The test for API Client
-class APIClientTest < PlaidTest
+class ApiClientTest < PlaidTest
   def test_api_client_exposes_farday_connection
     configuration = Plaid::Configuration.new
     configuration.server_index = Plaid::Configuration::Environment["sandbox"]
@@ -19,5 +18,33 @@ class APIClientTest < PlaidTest
     )
 
     assert_kind_of(Faraday::Connection, api_client.connection)
+  end
+
+  def test_timeout_error
+    api_client = Plaid::ApiClient.new
+    exception = -> { raise Faraday::TimeoutError.new }
+    options = { header_params: {} }
+
+    error = assert_raises Plaid::ApiClient::ApiTimeoutError do
+      api_client.connection.stub :get, exception do
+        api_client.call_api(:get, 'dummy_path', options)
+      end
+    end
+
+    assert_equal 'Connection timed out', error.message
+  end
+
+  def test_connection_error
+    api_client = Plaid::ApiClient.new
+    exception = -> { raise Faraday::ConnectionFailed.new }
+    options = { header_params: {} }
+
+    error = assert_raises Plaid::ApiClient::ApiConnectionFailedError do
+      api_client.connection.stub :get, exception do
+        api_client.call_api(:get, 'dummy_path', options)
+      end
+    end
+
+    assert_equal 'Connection failed', error.message
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,22 @@
+require 'bundler'
+
+begin
+  Bundler.setup(:default, :development)
+rescue Bundler::BundlerError => e
+  warn e.message
+  warn 'Run `bundle install` to install missing gems'
+  exit e.status_code
+end
+
+require "plaid"
 require "minitest/autorun"
 require "minitest/around/unit"
 require "json"
 
-require_relative "../lib/plaid"
-
 # Internal: Default read timeout for HTTP calls in seconds.
 NETWORK_TIMEOUT = 600
 
-class PlaidTest < MiniTest::Test
+class PlaidTest < Minitest::Test
   attr_reader :client, :item, :access_token
 
   def create_client


### PR DESCRIPTION
This should be backwards compatible with the existing code as the new errors inherit from `ApiError` and maintain the same string signature of the previous errors.

Addresses the following issue: https://github.com/plaid/plaid-ruby/issues/428

@phoenixy1